### PR TITLE
yoonhye / 11월 4주차 금요일 / 2문제

### DIFF
--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 두 큐 합 같게 만들기.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 두 큐 합 같게 만들기.py
@@ -1,0 +1,38 @@
+# 한 번의 pop과 한 번의 insert를 합쳐서 작업을 1회 수행한 것으로 간주.
+# 각 큐의 원소 합을 같게 만들기 위해 필요한 작업의 최소 횟수 return
+# queue1, queue2는 정수 배열.
+
+from collections import deque
+
+def solution(queue1, queue2):
+    sum1 = sum(queue1)
+    sum2 = sum(queue2)
+
+    total = sum1 + sum2
+    if (total % 2 != 0):
+        return -1
+
+    queue1 = deque(queue1)
+    queue2 = deque(queue2)
+
+    limit = len(queue1) * 3
+    num = 0
+
+    while (1):
+        if (num > limit):
+            return -1
+
+        if (sum1 > sum2):
+            num += 1
+            v = queue1.popleft()
+            sum2 += v
+            sum1 -= v
+            queue2.append(v)
+        elif (sum1 < sum2):
+            num += 1
+            v = queue2.popleft()
+            sum1 += v
+            sum2 -= v
+            queue1.append(v)
+        else:
+            return num

--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 성격 유형 검사하기.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 성격 유형 검사하기.py
@@ -1,0 +1,34 @@
+# 하나의 지표에서 각 성격 유형 점수가 같으면, 두 성격 유형 중 사전 순으로 빠른 성격 유형을 검사자의 성격 유형이라고 판단한다.
+# 지표 번호 순서대로 return
+# 비동의 / 동의
+# 사전순으로 더 앞에 있는게 점수를 얻으면 +, 아니면 -
+# 1 - 3 / 2 - 2 / 3 - 1 / 4 - 0 / 5 - 1 / 6 - 2 / 7 - 3
+# math.ceil(3/x)
+
+import math
+
+def solution(survey, choices):
+    answer = ''
+    mbti = {"RT": 0, "CF": 0, "JM": 0, "AN": 0}  # 1~4번 지표
+    for group, value in zip(survey, choices):
+        if (value >= 4):
+            value -= 4  # group[1]한테 점수 부여
+            if (group[1] > group[0]):  # group[1]이 사전순으로 더 뒤에 있는 경우
+                mbti[group[0] + group[1]] -= value
+            else:  # group[1]이 사전순으로 더 앞에 있는 경우
+                mbti[group[1] + group[0]] += value
+
+        else:  # group[0]한테 점수 부여
+            value = math.ceil(3 / value)
+            if (group[1] > group[0]):  # group[0]이 사전순으로 더 앞에 있는 경우
+                mbti[group[0] + group[1]] += value
+            else:  # group[0]이 사전순으로 더 뒤에 있는 경우
+                mbti[group[1] + group[0]] -= value
+
+    for key in mbti:
+        if mbti[key] < 0:  # 사전순으로 더 뒤에 있는거 출력
+            answer += key[1]
+        else:  # 사전순으로 더 앞에 있는거 출력
+            answer += key[0]
+
+    return answer


### PR DESCRIPTION
# [PGS] 성격 유형 검사하기

⏰ **41분 43초**  📌**구현**

- **`문제`**
    
    https://school.programmers.co.kr/learn/courses/30/lessons/118666?language=python3
    
- **`접근`**
    - 1~4번 지표까지 초기 값은 0으로 한 딕셔너리를 생성한다. (`{"RT": 0, "CF": 0, "JM" : 0, "AN": 0}`) 각 지표는 사전 순으로 정렬되어 있다.
    - 사전순으로 더 앞에 있는 유형이 점수를 획득하는 경우 딕셔너리에서 해당하는 점수만큼 지표에 +해주고, 사전순으로 더 뒤에 있는 유형이 점수를 획득하는 경우 딕셔너리에서 해당하는 점수만큼 지표에 -를 해준다.
    - 최종적으로 하나의 지표 값이 0보다 크거나 같으면 사전순으로 더 앞에 있는 유형을 출력하고, 0보다 작으면 사전순으로 더 뒤에 있는 유형을 출력한다.
- **`구현`**
    - value가 4보다 작은 경우에 value 값을 초기에 value += 2 로 잘못생각했어서 다시 생각한다고 시간을 꽤 잡아먹었다. 1일 때 3점, 2일 때 2점, 3일 때 1점이므로 `math.ceil`을 이용하여 3/value 값을 반올림해주면 원하는 값이 나온다.



# [PGS] 두 큐 합 같게 만들기

**⏰ 34분 27초  📌Greedy**

- **`문제`**
    
   https://school.programmers.co.kr/learn/courses/30/lessons/118667?language=python3
    
- **`접근`**
    - 각 큐의 원소 합을 같게 만들기 위해서는, 원소의 합이 더 큰 쪽에서 더 작은 쪽으로 원소를 이동시키는 작업을 반복하면 된다.
    - 주어진 queue1, queue2는 배열이므로, pop(0)을 하게 되면 시간 초과가 날 확률이 높다. 따라서 queue1, queue2를 deque로 만들어준다.
    - 두 큐의 원소 합을 같게 만들 수 없는 경우에는 -1을 return 해주도록 한다.
        - 전체 합이 홀수이면 queue1, queue2는 정수 배열이므로 두 큐의 원소 합을 같게 만들 수 없다. 따라서 -1을 return 해준다.
        - 이동 횟수가 (배열의 길이)*3을 넘어가면 두 큐의 원소 합을 같게 만들 수 없다는 의미이므로 -1을 return 해준다.
- **`구현`**
    - 처음에 sum1, sum2라고 변수를 설정하지 않고 그 자리에 그냥 sum(queue1), sum(queue2)를 하니까 시간 초과가 났다. sum()의 시간복잡도는 O(n)이므로 그때그때 sum을 해주는건 비효율적이다.
    - limit를 초기에는 len(queue1) * 2로 나뒀었는데(초기 queue1, queue2의 배열의 길이가 같고, 최대 이동 횟수가 전체 배열의 길이를 넘지 않을 거라고 생각했기 때문) 이렇게 하니까 테스트케이스1에서 오류가 났다. (나머지는 전부 통과)
    - limit 문제인가 싶어서 limit를 대충 원래 값에서 2배를 해줬더니 전체 통과가 되었다.
    - limit를 최종적으로 len(queue1) * 3으로 해주었는데, 최대 이동 횟수가 한 배열의 원소를 다른 배열에 모두 넣고(n번), 다른 배열의 모든 원소(총 2n개)를 다시 비어있는 배열에 넣었을 때의 횟수(n+2n =  3n번)를 넘지 않을 것이라고 생각했기 때문이다.
  