### PR TITLE
yoonhye / 11월 5주차 월요일 / 1문제

### DIFF
--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 등산코스 정하기.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 등산코스 정하기.py
@@ -1,0 +1,45 @@
+# 출입구, 쉼터, 산봉우리
+# 휴식 없이 이동해야 하는 시간 중 가장 긴 시간 => intensity
+# 쉼터 혹은 산봉우리를 방문할 때마다 휴식을 취할 수 있다. => 연속적으로 휴식없는 이동이 발생하지 X.
+# 특정 출입구에서 출발하여 산봉우리 중 한 곳만 방문한 뒤 다시 원래의 출입구로 돌아오는 등산코스.
+# 출입구 = 처음, 끝 각각 한 번씩. 산봉우리 = 한 번만
+# intensity가 최소가 되도록 등산코스를 정한다.
+# intensity가 최소가 되는 등산코스에 포함된 산봉우리 번호와 intensity의 최솟값을 차례대로 정수 배열에 담아 return
+# 등산코스가 여러 개라면, 그 중 산봉우리의 번호가 가장 낮은 등산코스 선택
+# 임의의 두 지점 사이에 이동 가능한 경로가 항상 존재.
+# 1<=w<= 10,000,000
+
+import heapq
+
+def solution(n, paths, gates, summits):
+    info = [[] for _ in range(n + 1)]
+    for a, b, c in paths:
+        info[a].append((b, c))  #a -> b까지 걸리는 시간 c
+        info[b].append((a, c))  #b -> a까지 걸리는 시간 c
+    INF = int(1e9)
+    intensity = [(INF) for _ in range(n+1)]
+    queue = []
+    isSummit = [False for _ in range(n+1)]
+    for summit in summits:
+        isSummit[summit] = True
+    for start in gates:
+        intensity[start] = 0
+        heapq.heappush(queue, (0, start))
+
+    while queue :
+        cost, a = heapq.heappop(queue)    #현재 노드까지의 최소 intensity, 현재 노드
+        if (isSummit[a] or (intensity[a] < cost)):
+            continue
+        for b, c in info[a]:    #현재노드 a와 인접한 노드 b, a에서 b까지 가는 데 걸리는 시간 c
+            if (intensity[b] > max(cost, c)):
+                intensity[b] = max(cost, c)
+                heapq.heappush(queue, (intensity[b], b))
+
+    res_summit = INF
+    res_intensity = INF
+    summits.sort()
+    for summit in summits:
+        if intensity[summit] < res_intensity:
+            res_intensity = intensity[summit]
+            res_summit = summit
+    return [res_summit, res_intensity]


### PR DESCRIPTION
# [PGS] 등산코스 정하기 - ⭐

**⏰ 3시간 50분  📌다익스트라(Dijkstra)**  ⭐**꼭 나중에 다시 풀어보기**

- **`문제`**
    
    https://school.programmers.co.kr/learn/courses/30/lessons/118669
    
- **`접근`**
    - 한 출입구에서 산봉우리를 거쳐 다시 원래의 출입구로 돌아오는 데 intensity가 최소가 되도록 해야한다. 굳이 왕복을 생각할 필요가 없는게, 한 출입구에서 산봉우리까지의 경로를 구했으면 그 경로대로 다시 돌아오면 되기 때문에 특정 출입구에서 특정 산봉우리까지의 최소 intensity를 구하면 되는 문제이다.
    - 한 정점(노드)에서 다른 모든 정점까지의 최단 경로를 구하는 알고리즘인 다익스트라를 이용할 수 있다. 이 문제에서는 최단 경로를 구하는 것이 아니라 경로상에서 가장 큰 간선의 값이 최소가 되도록 해야하므로 기존의 다익스트라에서 약간 변형해줘야한다.
    - 이 문제에서는 시간 제한이 빡빡하기 때문에 모든 출입구에 대해서 한 번씩 다익스트라 알고리즘을 실행해 정답을 찾으면 시간 초과가 발생한다. 그러므로 한 번의 다익스트라에서 모든 출입구를 시작 정점으로 두고 알고리즘을 실행해야 시간 초과를 피할 수 있다. `- 이게 너무 어려웠다.. 어떻게 생각함 대체? ㅠ`
    - 나는 계속 각 출입구에서 산봉우리까지의 최소 intensity를 생각했는데, 이 문제의 핵심은 어느 출입구에서 출발하는지는 상관이 없으므로 출입구에 대한 정보를 굳이 기억하지 않아도 된다는 점인 것 같다. 즉 bfs로 하든, 다익스트라로 하든 각 출입구에 대해서가 아니라 전체에 대해 한 번만 수행하도록 해야한다.
- **`구현`**
    - 초기에 intensity 배열에서 출입구에 해당하는 값을 0으로 초기화해주면, 이후부터 다시는 출입구에 대해 고려하지 않아도 된다. (즉, 출입구를 여러번 방문하는 일은 없다)
    - isSummit배열을 따로 두지 않고 `if (isSummit[a] or (intensity[a] < cost))` 이 부분에서 `isSummit[a]` 대신 `a not in summits` 으로 하면 25번 테스트케이스에서 시간 초과가 된다. isSummit 배열을 두면 한 번 비교할 때 `O(1)`만큼의 시간복잡도를 가지지만, summits 배열에 존재하는지 확인하는 것은 summits 배열의 길이만큼인 `O(n)`의 시간복잡도를 가지기 때문이다.