### PR TITLE
guyujung / 12월 1주차 금요일 / 1문제

### DIFF
--- a/yujung/백준/최단경로-다익스트라.cpp
+++ b/yujung/백준/최단경로-다익스트라.cpp
@@ -1,0 +1,52 @@
+//다익스트라-최단경로
+#include<iostream>
+#include<queue>
+#include<vector>
+#define endl "\n"
+#define  MAX 20010
+#define INF 987654321
+using namespace std;
+
+int v, e, start;
+int dist[MAX];
+vector<pair<int, int>> vertex[MAX];
+
+void dijkstra() {
+	priority_queue<pair<int, int>> pq;
+	pq.push(make_pair(0, start));
+	dist[start] = 0;
+	while (!pq.empty()) {
+		int cost = -pq.top().first;
+		int cur = pq.top().second;
+		pq.pop();
+		for (int i = 0; i < vertex[cur].size(); i++) {
+			int next = vertex[cur][i].first;
+			int nCost = vertex[cur][i].second;
+			if (dist[next] > cost + nCost)
+			{
+				dist[next] = cost + nCost;
+				pq.push(make_pair(-dist[next], next));
+
+			}
+		}
+	}
+	for (int i = 1; i <= v; i++) {
+		if (dist[i] == INF)cout << "INF" << endl;
+		else cout << dist[i] << endl;
+	}
+
+}
+int main() {
+	cin >> v >> e >> start;
+	for (int i = 0; i < e; i++) {
+		int a, b, c;
+		cin >> a >> b >> c;
+		vertex[a].push_back(make_pair(b, c));
+	}
+	for (int i = 1; i <= v; i++) {
+		dist[i] = INF;
+	}
+	dijkstra();
+
+	
+}


### PR DESCRIPTION

**다익스트라는 특정 노드와 연결된 최단거리를 구할 때 사용
**단점 가중치가 음수일때는 사용 불가

**Dijkstra의 알고리즘에서 pq.push(make_pair(-dist[next], next));라는 코드에서 -를 붙이는 이유는 우선순위 큐를 사용하여 노드의 거리 값을 관리할 때, 작은 거리 값을 우선적으로 처리하기 위함이다.
예를 들어 1,2,3 중에서 가장 우선순위가 높았던 것이 3이었는데 이를 음수로 바꾸게 되면 -1,-2,-3 이 되므로 -1이 가장 우선순위가 높게 된다. 최단 경로는 가장 짧은 것이 우선순위가 높아야 하므로 - 를 붙인다. 
그러나 실게 cost를 합산 할 때는 양수이어야 하므로 int cost = -pq.top().first; 에서 다시 -를 붙여 원래의 거리 값을 얻어내게 된다