### PR TITLE
yoonhye / 12월 2주차 월요일 / 1문제

### DIFF
--- a/yoonhye/BAEKJOON/[BOJ] 정수 삼각형.py
+++ b/yoonhye/BAEKJOON/[BOJ] 정수 삼각형.py
@@ -1,0 +1,24 @@
+#맨 위층부터 시작해서 아래에 있는 수 중 하나를 선택하여 아래층으로 내려올 때, 이제까지 선택된 수의 합이 최대가 되는 경로
+#아래층에 있는 수는 현재 층에서 선택된 수의 대각선 왼쪽 또는 대각선 오른쪽에 있는 것 중에서만 선택할 수 있다.
+n = int(input())
+board = [[] for _ in range(n)]
+for i in range(n):
+    board[i] = list(map(int, input().split()))
+
+dp = [[] for _ in range(n)] #dp[i][j] =>(i,j)가 선택됐을 때, 이때가지 선택된 수들의 최댓값. i층 j번까지의 최댓값.
+                            # board[i][j] + max(dp[i-1][j], dp[i-1][j-1)]
+for i in range(n):
+    dp[i] = [0 for _ in range(i+1)]
+
+dp[0][0] = board[0][0]
+
+for i in range(1, n):
+    for j in range(i+1):
+        if j == 0 :
+            dp[i][j] = dp[i-1][0] + board[i][j]
+        elif j == i :
+            dp[i][j] = dp[i-1][j-1] + board[i][j]
+        else:
+            dp[i][j] = max(dp[i-1][j], dp[i-1][j-1]) + board[i][j]
+
+print(max(dp[n-1]))


### PR DESCRIPTION
# [BOJ] 정수 삼각형

**⏰ 2시간 00분  📌DP** 

- **`문제`**
    
    [[1932번: 정수 삼각형](https://www.acmicpc.net/problem/1932)](https://www.acmicpc.net/problem/1932)
    
- **`접근`**
    - 맨 위층부터 시작해서 아래에 있는 수 중 하나를 선택하여 아래층으로 내려올 때, 이제까지 선택된 수의 합이 최대가 되도록 하는 문제이다.
    - 아래층에 있는 수는 현재 층에서 선택된 수의 대각선 왼쪽 또는 대각선 오른쪽에 있는 것 중에서만 선택할 수 있다.
    - 이 문제는 당장 큰 값을 선택하는 Greedy 방식을 사용하면 풀 수 없다. 그러므로 삼각형 내의 모든 지점을 고려하여서, 각 지점까지의 최댓값을 계산해야한다.
    - 초기 dp 배열을 dp = [[0], [0,0], [0,0,0], [0,0,0,0], …]로 초기화해준다.
    - dp[i][j] ⇒ 마지막 목적지가 `(i,j)`일 때, `(i,j)`까지 경로의 합들 중 최댓값을 의미한다. 즉, dp[i][j]는 다음 점화식을 만족한다. ((i,j) 이전에 (i-1,j) 또는 (i-1,j-1)만 올 수 있기 때문)
        
        `dp[i][j] = max(dp[i-1][j], dp[i-1][j-1]) + (i,j)값`
        
    - 각 층마다 맨 왼쪽 지점은(`j=0`일 때) 갈 수 있는 경로가 한가지 뿐이므로 예외처리해준다.
        
        `dp[i][j] = dp[i-1][0] + board[i][j] (단, j == 0)`
        
    - 마찬가지로 각 층마다 맨 오른쪽 지점도(`j=i`일 때) 갈 수 있는 경로가 1가지 뿐이므로 예외처리해준다.
        
        `dp[i][j] = dp[i-1][j-1] + board[i][j] (단, j == i)`
        
- **`구현`**
    - 위에서 구한 점화식을 이용하여 구현한다.