### PR TITLE
yoonhye / 1월 1주차 월요일 / 1문제

### DIFF
--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
@@ -1,26 +1,54 @@
 from collections import deque
 
+
 def solution(rc, operations):
     M = len(rc[0])  # 열의 개수
-    N = len(rc)  # 행의 개수
-    start = 0
-    end = N - 1
 
-    rc_deque = deque([])
-    for arr in rc:
-        rc_deque.append(deque(arr))
+    # 예외처리 (열이 2개만 있는 경우 - 런타임 에러 방지)
+    if M == 2:
+        first_col = deque()
+        last_col = deque()
+        for arr in rc:
+            first_col.append(arr[0])
+            last_col.append(arr[1])
 
-    for op in operations:
-        if op == "Rotate":
-            # 첫 열 : popleft해서 한 행 위에 appendleft
-            # 마지막 열 : pop해서 한 행 밑에 append
-            for i in range(1, N):
-                rc_deque[i - 1].appendleft(rc_deque[i].popleft())
-                rc_deque[N - i].append(rc_deque[N - i - 1].pop())
-        else:
-            rc_deque.appendleft(rc_deque.pop())
+        for op in operations:
+            if op == "Rotate":
+                last_col.appendleft(first_col.popleft())
+                first_col.append(last_col.pop())
+            else:
+                first_col.appendleft(first_col.pop())
+                last_col.appendleft(last_col.pop())
+        result = []
+        for fc, lc in zip(first_col, last_col):
+            result.append([fc, lc])
 
-    result = []
-    for deq in rc_deque:
-        result.append(list(deq))
+    else:
+        first_col = deque()
+        last_col = deque()
+        rc_deque = deque()
+        for arr in rc:
+            arr = deque(arr)
+            first_col.append(arr.popleft())
+            last_col.append(arr.pop())
+            rc_deque.append(arr)
+
+        for op in operations:
+            if op == "Rotate":
+                last_col.appendleft(rc_deque[0].pop())
+                rc_deque[-1].append(last_col.pop())
+                first_col.append(rc_deque[-1].popleft())
+                rc_deque[0].appendleft(first_col.popleft())
+            else:
+                last_col.appendleft(last_col.pop())
+                first_col.appendleft(first_col.pop())
+                rc_deque.appendleft(rc_deque.pop())
+
+        result = []
+        for fc, arr, lc in zip(first_col, rc_deque, last_col):
+            row = []
+            row.append(fc)
+            row.extend(arr)
+            row.append(lc)
+            result.append(row)
     return result

--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
@@ -1,36 +1,37 @@
-def ShiftRow(rc, N):
-    new_rc = [0] * N
-    for i in range(N - 1):
-        new_rc[i + 1] = rc[i]
-    new_rc[0] = rc[-1]
-    return new_rc
-
+from collections import deque
 
 def Rotate(rc, N, M):
-    new_rc = [item[:] for item in rc]
-    for a in range(0, M - 1):  # 첫 행에서 끝 열에 있는 원소를 제외한 첫 행의 모든 원소는 오른쪽으로 한 칸 이동
-        new_rc[0][a + 1] = rc[0][a]
+    row = [rc[0][:], rc[-1][:]]  # 첫 행, 마지막 행
 
-    for b in range(0, N - 1):  # 끝 열에서 끝 행에 있는 원소를 제외한 끝 열의 모든 원소는 아래쪽으로 한 칸 이동
-        new_rc[b + 1][-1] = rc[b][-1]
+    column = [[], []]  # 첫 열, 마지막 열
+    for k in range(N):
+        column[0].append(rc[k][0])
+        column[1].append(rc[k][-1])
 
-    for c in range(1, M):  # 끝 행에서 첫 열에 있는 원소를 제외한 끝 행의 모든 원소는 왼쪽으로 한 칸 이동
-        new_rc[-1][c - 1] = rc[-1][c]
+    rc[0][1] = row[0][0]
+    rc[-1][M - 2] = row[1][M - 1]
+    for i in range(1, M - 1):
+        rc[0][i + 1] = row[0][i]
+        rc[-1][i - 1] = row[1][i]
 
-    for d in range(1, N):  # 첫 열에서 첫 행에 있는 원소를 제외한 첫 열의 모든 원소는 위쪽으로 한 칸 이동
-        new_rc[d - 1][0] = rc[d][0]
-
-    return new_rc
+    rc[1][-1] = row[0][-1]
+    rc[N - 2][0] = row[1][0]
+    for j in range(1, N - 1):
+        rc[j + 1][-1] = column[1][j]
+        rc[j - 1][0] = column[0][j]
+    return rc
 
 
 def solution(rc, operations):
     M = len(rc[0])  # 열의 개수
     N = len(rc)  # 행의 개수
-
+    start = 0
+    end = N - 1
+    rc = deque(rc)
     for op in operations:
         if op == "Rotate":
             rc = Rotate(rc, N, M)
         else:
-            rc = ShiftRow(rc, N)
+            rc.appendleft(rc.pop())
 
-    return rc
+    return list(rc)

--- a/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
+++ b/yoonhye/KAKAO/2022_TECH_INTERNSHIP/[PGS] 행렬과 연산.py
@@ -1,37 +1,26 @@
 from collections import deque
 
-def Rotate(rc, N, M):
-    row = [rc[0][:], rc[-1][:]]  # 첫 행, 마지막 행
-
-    column = [[], []]  # 첫 열, 마지막 열
-    for k in range(N):
-        column[0].append(rc[k][0])
-        column[1].append(rc[k][-1])
-
-    rc[0][1] = row[0][0]
-    rc[-1][M - 2] = row[1][M - 1]
-    for i in range(1, M - 1):
-        rc[0][i + 1] = row[0][i]
-        rc[-1][i - 1] = row[1][i]
-
-    rc[1][-1] = row[0][-1]
-    rc[N - 2][0] = row[1][0]
-    for j in range(1, N - 1):
-        rc[j + 1][-1] = column[1][j]
-        rc[j - 1][0] = column[0][j]
-    return rc
-
-
 def solution(rc, operations):
     M = len(rc[0])  # 열의 개수
     N = len(rc)  # 행의 개수
     start = 0
     end = N - 1
-    rc = deque(rc)
+
+    rc_deque = deque([])
+    for arr in rc:
+        rc_deque.append(deque(arr))
+
     for op in operations:
         if op == "Rotate":
-            rc = Rotate(rc, N, M)
+            # 첫 열 : popleft해서 한 행 위에 appendleft
+            # 마지막 열 : pop해서 한 행 밑에 append
+            for i in range(1, N):
+                rc_deque[i - 1].appendleft(rc_deque[i].popleft())
+                rc_deque[N - i].append(rc_deque[N - i - 1].pop())
         else:
-            rc.appendleft(rc.pop())
+            rc_deque.appendleft(rc_deque.pop())
 
-    return list(rc)
+    result = []
+    for deq in rc_deque:
+        result.append(list(deq))
+    return result


### PR DESCRIPTION
# 행렬과 연산

**⏰ 3시간 00분 (정확성 : 25분, 효율성 : 2시간 35분 걸림)  📌deque, 링크드리스트**

- **`문제`**
    
    (https://school.programmers.co.kr/learn/courses/30/lessons/118670)

- **`접근`**
    - 초반에는 문제에서 구현하라는대로 구현했더니 정확성은 통과했고, 효율성은 통과하지 못했다. 초기 시간복잡도 : ShiftRow - O(N), Rotate - O(NM)
        
    - 시간을 줄이기 위해 고민해본 결과 ShiftRow는 링크드 리스트를 사용하면 기존에 O(N)의 시간복잡도를 가지던 것을 O(1)의 시간복잡도로 줄일 수 있을 거라고 생각했다. 마지막 행을 첫 번째 행으로 옮기면 되는데, 링크드리스트에서는 삽입과 삭제가 O(1)이 걸리기 때문이다.
        
        → 잘못된 생각인게, 링크드리스트에서는 head 노드에 대한 정보만 가지고 있기 때문에 마지막 위치에 있는 노드의 정보를 얻기 위해서는 O(N)의 시간이 걸린다. 즉, 마지막 노드를 찾아서 첫 번째 노드로 보낸다면 총 O(N)이 걸릴 것이다. (마지막 노드 찾기 : O(N), 연결을 끊고 맨 앞에 삽입 : O(1))
        
    - 아무튼 처음에는 링크드 리스트로도 O(1)이 걸린다고 생각하고 그렇게 시도해보려고 했지만 ShiftRow를 그렇게 해결한 뒤 Rotate할 때 배열이 아닌 링크드리스트 형태에서 어떻게 해야할지 감이 안 잡혔었다.
    - 링크드리스트를 대체할 것을 찾다가 **deque에서 선입, 후입, 선출, 후출 모두 O(1)**이 걸린다는 사실을 알아냈다. deque()는 Queue랑 Stack의 특징을 모두 가져온 리스트라고 생각하면 편하다. (처음에 deque를 그냥 Queue라고만 생각했었다…)
    - deque의 pop()과 appendleft()를 이용하면 ShiftRow를 O(1)에 처리할 수 있다.
    - rc의 각 행도 deque로 두고, 각 행에서 popleft()를 통해 꺼낸 각 행의 첫 번째 원소를 한 행 위에 appendleft()해주고, pop()을 통해 꺼낸 마지막 원소를 한 행 밑에 append() 해주면 Rotate도 처리할 수 있다.
        - 코드
            
            ```python
            # 첫 열 : popleft해서 한 행 위에 appendleft
            # 마지막 열 : pop해서 한 행 밑에 append
            for i in range(1, N):
                rc_deque[i - 1].appendleft(rc_deque[i].popleft())
                rc_deque[N - i].append(rc_deque[N - i - 1].pop())
            ```
            
        
        하지만 이렇게 했더니 효율성 테스트케이스 9개 중에 4개는 실패했다. 이 방식으로는 행이 N개 있을 때 O(N)만큼이 걸리는데 이걸 더 줄여야한다. (이걸 총 operations의 길이만큼 Q번 반복한다고 했을 때 최종적으로  O(NQ)인데, O(NQ)의 최댓값은 50억이다)
        
    
    `→ 여기까지는 혼자 해냈는데 도저히 더 줄일 방법이 생각나지 않아서 힌트를 참고했다.`
    
    - 배열을 1. 첫번째 열(1차원) 2. 마지막 열(1차원) 3. 그 외 나머지 배열(2차원) 이렇게 쪼개면 Rotate()도 O(1)으로 처리할 수 있다. 이때 첫 번째 열, 마지막 열, 나머지 배열 모두 deque()로 만들어줘야한다.
        
        ![Untitled](https://tech.kakao.com/storage/2022/07/image6.png)

        
        - 첫 번째 열 : first_col, 마지막 열 : last_col, 그 외 : rc_deque
        - 첫 번째 열 : popleft() 후 rc_deque[0]에 appendleft()
        - 마지막 열 : pop() 후 rc_deque[-1]에 append()
        - 그 외 :
            - 첫 행(rc_deque[0]) : pop() 후 last_col에 appendleft()
            - 마지막 행(rc_deque[-1]) : popleft()후 first_col에 append()
        
        → 이렇게 하면 Rotate도 O(1)의 시간복잡도를 가진다.
        
    - operations의 길이를 Q라고 할 때, 최종적으로 시간복잡도는 다음과 같다.
        - `O(NM + Q)`
            
            → O(Q) : Rotate, ShiftRow 연산 총 Q번.
            
            → O(NM) : first_col, last_col, rc_deque를 만드는 연산 & 모든 연산 끝나고 result 배열로 합치는 연산

<ul>
<li><strong><code>참고</code></strong>
<ul>
<li>
<p>시간 제한이 1초인 경우, 시간 복잡도와 입력 크기의 관계</p>

N의 최댓값 | Big O
-- | --
500(5백) | O(N^3)
2,000(2천) | O(N^2)
100,000(10만) | O(NlogN)
10,000,000(1000만) | O(N)


</li>
</ul>
</li>
</ul>
<!-- notionvc: 97c62ca7-36c9-4b10-9fde-a898dbf2cd32 -->

- **`구현`**
    - 열이 2개인 경우에 대해서 예외처리를 해줘야한다. 안 해주면 효율성 테케 4, 6에서 런타임 에러가 난다. 열이 2개이면 rc_deque 배열이 빈 배열이기 때문에 index 에러가 발생하기 때문이다.
   