### PR TITLE
yoonhye / 1월 4주차 금요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 비바라기.py
+++ b/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 비바라기.py
@@ -16,19 +16,19 @@ from collections import deque
 def cloud_move(d, s):   #구름 이동 함수
     global N
     new_cloud = []
-    dx, dy = dir[d]
+    dx, dy = dir[d][0]*s, dir[d][1]*s
     for x, y in cloud:
-        for _ in range(s):
-            x, y = x+dx, y+dy
-            if x == -1:
-               x = N-1
-            elif x == N:
-                x = 0
-            if y == -1:
-                y = N-1
-            elif y == N:
-                y = 0
-        new_cloud.append((x,y))
+        nx, ny = x+dx, y+dy
+        if nx<0:
+            nx += ((abs(nx+1)//N)+1) * N
+        elif nx>0:
+            nx %= N
+        if ny<0:
+            ny += ((abs(ny + 1) // N) + 1) * N
+        elif ny>0:
+            ny %= N
+        new_cloud.append((nx,ny))
+        visited[nx][ny] = 1
     return new_cloud
 
 def water_copy():
@@ -42,7 +42,6 @@ def water_copy():
             if board[nx][ny]:   #물이 있으면
                 board[x][y] += 1
 
-
 N, M = map(int, input().split())
 board = [list(map(int, input().split())) for _ in range(N)]
 move_info = deque()
@@ -51,21 +50,22 @@ for _ in range(M):
     d, s = map(int, input().split())
     move_info.append((d,s))
 cloud = [(N-1,0), (N-1,1), (N-2,0), (N-2,1)]
-
+visited = [[0 for _ in range(N)] for _ in range(N)]
 for _ in range(M):
     d, s = move_info.popleft()
     cloud = cloud_move(d,s)
     for x, y in cloud:
         board[x][y] += 1
-    del_cloud = dict().fromkeys(cloud,0)
     water_copy()
     cloud = []
 
     for i in range(N):
         for j in range(N):
-            if board[i][j] >= 2 and del_cloud.get((i,j)) == None:
+            if board[i][j] >= 2 and visited[i][j] == 0:
                 cloud.append((i,j))
                 board[i][j] -= 2
+            elif visited[i][j] == 1:
+                visited[i][j] = 0
 res = 0
 for i in range(N):
     res += sum(board[i])

--- a/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 비바라기.py
+++ b/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 비바라기.py
@@ -1,0 +1,72 @@
+#바구니에 저장할 수 있는 물의 양에는 제한이 없다.
+#(1,1) ~ (N,N)
+#1번 열 왼쪽에 N번 열, 1번 행 위쪽에 N번 행 존재.
+#(N,1), (N,2), (N-1,1), (N-1,2)에 비구름이 생김. 구름은 칸 전체를 차지한다.
+#왼쪽부터 시계방향으로 총 8개의 방향. (1~8)
+#1. 모든 구름이 d 방향으로 s칸 이동
+#2. 각 구름에서 비가 내려 구름이 있는 칸의 바구니에 저장된 물의 양이 1 증가
+#3. 구름이 모두 사라짐
+#4. 2에서 물이 증가한 칸에 물복사버그 마법 시전.
+#   대각선 방향으로 거리가 1인 칸에 물이 있는 바구니의 수만큼 마법 시전한 칸에 있는 바구니의 물 양이 증가.
+#   이동과 다르게 경계를 넘어가는 칸은 대각선 방향으로 거리가 1인 칸이 X!!
+#5. 바구니에 저장된 물의 양이 2 이상인 모든 칸에 구름이 생기고, 물의 양이 2 줄어듦.
+#   이때 구름이 생기는 칸은 3에서 구름이 사라진 칸이 아니어야 한다.
+#M번 이동 후 바구니에 들어있는 물의 양의 합
+from collections import deque
+def cloud_move(d, s):   #구름 이동 함수
+    global N
+    new_cloud = []
+    dx, dy = dir[d]
+    for x, y in cloud:
+        for _ in range(s):
+            x, y = x+dx, y+dy
+            if x == -1:
+               x = N-1
+            elif x == N:
+                x = 0
+            if y == -1:
+                y = N-1
+            elif y == N:
+                y = 0
+        new_cloud.append((x,y))
+    return new_cloud
+
+def water_copy():
+    global N
+    delta = [(-1,-1), (-1,1), (1,-1), (1,1)]    #대각선
+    for x, y in cloud:
+        for dx, dy in delta:
+            nx, ny = x+dx, y+dy
+            if nx<0 or ny<0 or nx>=N or ny>=N:
+                continue
+            if board[nx][ny]:   #물이 있으면
+                board[x][y] += 1
+
+
+N, M = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(N)]
+move_info = deque()
+dir = [(0,0), (0,-1), (-1,-1), (-1,0), (-1,1), (0,1), (1,1), (1,0), (1,-1)] #1~8 => 왼쪽부터 시계방향
+for _ in range(M):
+    d, s = map(int, input().split())
+    move_info.append((d,s))
+cloud = [(N-1,0), (N-1,1), (N-2,0), (N-2,1)]
+
+for _ in range(M):
+    d, s = move_info.popleft()
+    cloud = cloud_move(d,s)
+    for x, y in cloud:
+        board[x][y] += 1
+    del_cloud = dict().fromkeys(cloud,0)
+    water_copy()
+    cloud = []
+
+    for i in range(N):
+        for j in range(N):
+            if board[i][j] >= 2 and del_cloud.get((i,j)) == None:
+                cloud.append((i,j))
+                board[i][j] -= 2
+res = 0
+for i in range(N):
+    res += sum(board[i])
+print(res)


### PR DESCRIPTION
# [BOJ] 마법사 상어와 비바라기

**⏰ 0시간 53분  📌구현, 시뮬레이션**

- **`문제`**
    
    [[21610번: 마법사 상어와 비바라기](https://www.acmicpc.net/problem/21610)](https://www.acmicpc.net/problem/21610)
    
- **`접근`**
    - 비교적 간단한 구현 문제이다. 이 문제에서는 1열과 N열이 붙어있고, N행과 1행이 붙어있다는 사실만 신경쓰면 틀릴 부분이 없는 것 같다.
    - 비바라기를 시전하면 (N,1), (N,2), (N-1,1), (N-1,2)에 비구름이 생긴다. 나는 **(0,0)부터 배열을 구성했기 때문에 꼭 각 좌표에 (-1,-1)을 해줬어야 했다.**
    - `ver1`
        - 처음에 구현했을 때는 구름이 있던 칸(3번 과정에서 사라지는 구름이 있던 칸)을 저장할 딕셔너리 del_cloud를 두었다. 구름의 좌표를 배열로 저장하는 것과 딕셔너리로 저장하는 것만 생각했었고, 5번 과정에서 배열은 찾는데 시간이 O(배열의 길이)만큼 걸리므로 딕셔너리가 더 낫다고 판단했기 때문에 딕셔너리로 구성하였다. (찾는거 외에 다른 부분에서는 시간 복잡도 동일함)
        - 구름 이동함수에서 구름이 이동할 때 배열의 범위를 벗어나더라도 연결된 행 또는 열로 갈 수 있도록 구현했어야 했는데, 한 칸씩 이동하는 방법이 최악의 경우 O(N^2*s)의 시간복잡도가 걸리지만 N과 s의 최댓값이 50이기 때문에 이걸 총 M번(1≤M≤100) 반복하더라도 시간 제한 1초를 넘기지 않을거라고 판단했다.
        - 결과적으로 통과했고, `540ms`의 시간이 걸렸다.
    - `ver2`
        - 조금 더 효율적으로 구현하고자 다른 사람의 코드를 참고하고, 나의 생각을 더해서 코드를 수정했다.
        - 사라지는 구름을 저장하는 것은 이차원 배열 visited를 만들어서 방문 여부를 저장하는 방법으로 수정했다. 이렇게 하면 매번 기존 cloud 배열에 있던 값을 딕셔너리로 변환하는 과정이 필요가 없고, water_copy()할 때 visited[x][y] 값을 수정해주기만 하면 되기 때문에 약간은 더 효율적일 것이다. 이것만 수정했을 때는 `520ms`의 시간이 걸렸다.
        - 구름 이동 부분은 한 번에 이동하도록 수정해서 `ver1`에서처럼 이동을 s번 하지 않기 때문에 최악의 경우 O(N^2)이 걸리게 할 수 있었다.
        - 최종적으로 `280ms`의 시간으로 통과할 수 있었다.