### PR TITLE
yoonhye / 1월 5주차 월요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[BOJ] 상어 중학교.py
+++ b/yoonhye/SAMSUNG/[BOJ] 상어 중학교.py
@@ -1,0 +1,93 @@
+#모든 칸에는 블록이 하나씩 들어 있음. 일반 블록은 M가지 색상이 있고, 색은 M이하의 자연수. 검은색은 -1, 무지개는 0
+#인접한 칸 => abs(r1-r2) + abs(c1-c2) == 1  => 상하좌우로 거리 1이면 인접
+#그룹에는 일반 블록이 적어도 하나 있어야 하며, 일반 블록의 색은 모두 같아야 한다.
+#검은색은 포함하면 안 되고, 무지개는 얼마나 있든 상관X.
+#그룹에 속한 블록 수는 2이상, 임의의 한 블록에서 그룹에 속한 인접한 칸으로 이동해서 그룹에 속한 다른 모든 칸으로 이동할 수 있어야 한다.
+#블록 그룹의 기준 블록 : 일반 블록 중 행의 번호가 가장 작은 블록. (같으면 열이 가장 작은 블록)
+#블록 그룹이 존재하는 동안 계속 반복.
+#1. 크기가 가장 큰 블록 그룹을 찾는다. 크기가 같으면 포함된 무지개 블록 수가 가장 많은 블록, 기준 블록의 행이 큰 거, 열이 큰 거
+#2. 1에서 찾은 블록 그룹의 모든 블록을 제거. B^2 점 획득. ( B = 블록 수)
+#3. 격자에 중력이 작용(검은색 제외 모두 행의 번호가 큰 칸으로 이동. 이동은 다른 블록 or 격자의 경계를 만나기 전까지 계속됨)
+#4. 격자 90도 반시계 방향으로 회전
+#5. 다시 격자에 중력 작용
+#최종적으로 획득한 점수의 합 출력
+from collections import deque
+def bfs():
+    global N, res
+    visited = [[0 for _ in range(N)] for _ in range(N)]
+    delta = [(-1,0), (0,-1), (0,1), (1,0)]
+    queue = deque()
+    rainbow_num, row, column, group = 0, 0, 0, []
+    for i in range(N):
+        for j in range(N):
+            if board[i][j]>0 and visited[i][j] == 0:  #일반 블록이고, 한 번도 방문한 적 없으면
+                queue.append((i,j))
+                n = board[i][j]
+                nrainbow_num, nrow, ncolumn, ngroup = 0, i, j, []
+                rainbow = []
+                while(queue):
+                    x, y = queue.popleft()
+                    for dx, dy in delta:
+                        nx, ny = x+dx, y+dy
+                        if nx<0 or ny<0 or nx>=N or ny>=N or board[nx][ny] < 0:
+                            continue
+                        if visited[nx][ny] == 0:
+                            if board[nx][ny] == n or board[nx][ny] == 0:
+                                queue.append((nx, ny))
+                                visited[nx][ny] = 1
+                                ngroup.append((nx, ny))
+                            if board[nx][ny] == 0:    #무지개이면
+                                nrainbow_num += 1
+                                rainbow.append((nx,ny))
+
+                if len(group)<len(ngroup):
+                    rainbow_num, row, column, group = nrainbow_num, nrow, ncolumn, ngroup
+                elif len(group) == len(ngroup):
+                    if rainbow_num < nrainbow_num or ((rainbow_num == nrainbow_num) and (row, column) < (nrow,ncolumn)):
+                        rainbow_num, row, column, group = nrainbow_num, nrow, ncolumn, ngroup
+
+                for a, b in rainbow:    #무지개 방문 여부 초기화
+                    visited[a][b] = 0
+    if len(group) <= 1:
+        return False
+    res += (len(group) ** 2)
+    for i, j in group:
+        board[i][j] = -2
+    return True
+
+def gravity_and_rotate():
+    global N
+    new_board = []
+    for j in range(N - 1, -1, -1):
+        new_col = [-2 for _ in range(N)]
+        for i in range(N - 1, -1, -1):
+            r = i
+            if board[i][j] >= 0:
+                while (0 <= r < N - 1 and new_col[r + 1] == -2):
+                    r += 1
+            new_col[r] = board[i][j]
+
+        new_board.append(new_col)
+
+    return new_board
+def gravity():
+    global N
+    for j in range(N-1, -1, -1):
+        new_col = [-2 for _ in range(N)]
+        for i in range(N - 1, -1, -1):
+            r = i
+            if board[i][j] >= 0:
+                while (0<=r<N-1 and new_col[r+1] == -2):
+                    r += 1
+            new_col[r] = board[i][j]
+
+        for k in range(N):
+            board[k][j] = new_col[k]
+
+N, M = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(N)]
+res = 0
+while(bfs()):
+    board = gravity_and_rotate()
+    gravity()
+print(res)


### PR DESCRIPTION
# [BOJ] 상어 중학교

**⏰ 1시간 57분  📌 BFS, 구현, 시뮬레이션**

- **`문제`**
    
    [[21609번: 상어 중학교](https://www.acmicpc.net/problem/21609)](https://www.acmicpc.net/problem/21609)
    
- **`접근`**
    
    **[가장 큰 블록 찾기 - BFS]**
    
    - 크기가 가장 큰 블록 그룹을 찾기 위해서는 bfs를 이용해야 한다. 하나의 블록 그룹은 연결되어 있기 때문에 어느 한 지점에서 다른 지점으로 무조건 이동이 가능하므로, 처음 일반 블록 지점을 queue에 넣고 인접한 부분에 같은 색의 블록 혹은 무지개 블록이 있으면 queue에 넣어주는 방식으로 bfs를 수행한다. 그러면 출발 위치에서 나올 수 있는 가장 큰 블록 그룹을 구할 수 있다. 이 과정을 모든 일반 블록에 대해 수행한다.
    - 어떤 위치에 일반 블록이 존재하는지 모르니 격자의 모든 칸에 대하여 이전에 방문 하지 않았던 일반 블록이면 해당 위치에서부터 bfs를 수행한다. 같은 그룹에 속해 있으면 어느 위치에서 그룹을 구하든 똑같은 결과가 나오기 때문에 이전에 방문했던 일반 블록은 다시 bfs를 수행해보지 않아도 된다.
    - 주의할 점은 무지개 블록은 모든 일반 블록과 이어질 수 있으므로, 이전에 방문했더라도 다시 또 방문할 수 있게 visited의 값을 초기화해줘야 한다. (하나의 그룹을 찾는 과정을 완전히 끝낸 후 초기화 해줘야함.)
    - 위의 과정을 거친 후 크기가 가장 큰 블록을 찾으면 해당 부분을 -2로 바꿔준다. (내가 빈 공간을 -2로 정의했다.)
    
    **[중력 & 회전]**
    
    - 중력과 90도 반시계 방향으로 회전하는 것을 동시에 구현한 함수와 중력만 구현한 함수 2가지를 추가로 구현했는데, 이렇게 구현한 이유는 중력과 반시계 방향 회전 부분을 따로 구현하면 훨씬 비효율적이라고 생각했기 때문이다.
    - 중력을 구현할 때 가장 마지막 열부터 시작해서 중력이 적용된 새로운 열을 구하는데, 그 열을 그냥 new_board에 그대로 append만 해주면 중력이 작용한 뒤 반시계 방향으로 90도 회전한 배열을 구할 수 있기 때문이다. 회전을 따로 분리해서 구현하면 전체 배열의 크기만큼의 시간복잡도를 가질텐데 그건 너무 비효율적이라고 생각했다.
    - 중력 코드 작성하는데 시간이 꽤 오래 걸렸다… 이 부분 생각하는게 이 문제에서는 제일 어려웠다.
- **`구현`**
    - `bfs()` : 1~2 과정
    - `gravity_and_rotate()` : 3~4 과정
    - `gravity()` : 5 과정