### PR TITLE
yoonhye / 2월 2주차 금요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 파이어스톰.py
+++ b/yoonhye/SAMSUNG/[BOJ] 마법사 상어와 파이어스톰.py
@@ -1,0 +1,86 @@
+#1.격자를 2^L X 2^L 크기의 부분 격자로 나눈다.
+#2.모든 부분 격자를 시계 방향으로 90도 회전시킨다.
+#3.얼음이 있는 칸 3개 이상과 인접해있지 않은 칸은 얼음의 양이 1 줄어든다.
+#인접한 칸 => 상하좌우
+#남아있는 얼음의 합과 남아있는 얼음 중 가장 큰 덩어리가 차지하는 칸의 개수를 return
+
+from collections import deque
+def divide_and_rotate(n):
+    global N
+    new_board = [[0 for _ in range(2**N)] for _ in range(2**N)]
+    for i in range(0, 2**N, n):
+        for j in range(0, 2**N, n):
+            for k in range(n):
+                l = 0
+                for v in board[i+k][j:j+n]:
+                    new_board[i+l][j+n-1-k] = v
+                    l+=1
+
+    return new_board
+
+def decrease_ice():
+    global N
+    new_board = [board[i][:] for i in range(2**N)]
+    d = [(-1,0), (1,0), (0,-1), (0,1)]  #상하좌우
+    for x in range(2**N):
+        for y in range(2**N):
+            if board[x][y] == 0 :
+                continue
+            cnt = 4 #인접한 칸에 얼음이 있는 경우 중 칸의 개수의 최댓값 (상하좌우)
+            for dx, dy in d:
+                nx, ny = x+dx, y+dy
+                if nx<0 or ny<0 or nx>=2**N or ny>=2**N:
+                    cnt -= 1
+                    continue
+                if board[nx][ny] == 0 : #얼음이 없는 경우
+                    cnt -= 1
+                if cnt <= 2:
+                    break
+            if cnt <= 2:
+                new_board[x][y] -= 1
+    return new_board
+
+def find_ice_set():
+    global N
+    visited = [[0 for _ in range(2**N)] for _ in range(2**N)]
+    d = [(-1,0), (1,0), (0,-1), (0,1)]  #상하좌우
+    res = 0
+    for i in range(2**N):
+        for j in range(2**N):
+            if visited[i][j] or board[i][j]==0 :  #방문한 적이 있거나 얼음이 없으면
+                continue
+            queue = deque([(i,j)])
+            cnt = 0
+            visited[i][j] = 1
+            while(queue):
+                x, y = queue.popleft()
+                cnt += 1
+                for dx, dy in d:
+                    nx, ny = x+dx, y+dy
+                    if nx<0 or ny<0 or nx>=2**N or ny>=2**N:
+                        continue
+                    if board[nx][ny] and visited[nx][ny] == 0 :  #얼음이 있고 방문한 적이 없으면
+                        queue.append((nx,ny))
+                        visited[nx][ny] = 1
+            res = max(res, cnt)
+    return res
+
+N, Q = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(2**N)]
+L_list = list(map(int, input().split()))
+
+for q in range(Q):
+    if L_list[q] != 0:
+        n = 2 ** L_list[q]
+        board = divide_and_rotate(n)
+    board = decrease_ice()
+
+total_ice = 0
+ice_set_cnt = find_ice_set()
+for arr in board:
+    total_ice += sum(arr)
+
+print(total_ice)
+print(ice_set_cnt)
+
+


### PR DESCRIPTION
# [BOJ] 마법사 상어와 파이어스톰

**⏰ 1시간 20분  📌 구현, BFS**
- **`문제`**
    
    [[20058번: 마법사 상어와 파이어스톰](https://www.acmicpc.net/problem/20058)](https://www.acmicpc.net/problem/20058)
    
- **`접근`**
    - 부분 격자를 회전시키는 부분이 까다롭고 그 외에는 그냥 구현하면 된다.
    - 주의할 점은 인접한 칸 3개 이상에 얼음이 있지 않은 경우 얼음의 양을 1 줄어들게 할 때, 모든 칸에서 이 일이 동시에 발생하므로 얼음을 줄이기 이전 격자를 가지고 얼음의 양을 줄일지 말지 선택해야한다는 것이다. 즉, 새로운 격자를 만들어서 기존 격자는 선택의 용도로 사용하고 새로운 격자에서 얼음의 양을 줄여나가거나 어떤 칸의 얼음을 줄여야하는지 저장해두고 그 칸의 얼음을 한 번에 줄여나가는 방식을 사용할 수 있다.
    - 최종적으로 남아있는 얼음 중 가장 큰 덩어리가 차지하는 칸의 개수는 모든 칸에 대하여 BFS를 수행하여 구할 수 있다.
- **`구현`**
    
    
    | 체크할 문항 | 확인 |
    | --- | --- |
    | N의 값이 가장 작은 경우를 고려했는가? | ⭕️ |
    | N의 값이 가장 큰 경우를 고려했는가? | ⭕️ |
    | 중복 증가, 중복 감소되는 부분이 있는지 체크했는가? | ⭕️ |
    | 모든 원소가 정상적으로 처리됐는가? 마지막 원소를 빠뜨리지는 않았는가? | ⭕️ |
    | 조건문의 위치가 올바른가? | ⭕️ |
    | 초기값이 올바르게 설정됐는가? | ⭕️ |
    | 좌표값이 (1,1)부터 시작하는 경우, 내가 (0,0)으로 시작하도록 설정했다면 그것으로 인해 수정할 부분이 없는가? 있다면 수정했는가? | ⭕️ |
    - `decrease_ice()` 다른 방식 : 부분 격자 회전할 때 얼음이 없는 칸의 정보를 따로 저장해두고, `decrease_ice()` 함수에서 새로운 배열을 생성하는 대신 모든 칸에 대하여 인접한 칸 중 얼음이 있는 칸의 개수(Ex. ice_cnt. 초기값 : 4)를 저장하는 배열을 생성한다. 그리고 앞에서 저장해놓았던 얼음이 없는 칸에 대해서만 인접한 칸의 ice_cnt 값을 1 감소시킨다. 최종적으로 ice_cnt의 값이 3보다 작으면 그 칸의 얼음을 1 감소시키는 방식으로도 코드를 짤 수 있다. (이때 주의할 점은 가장 바깥쪽 칸들의 ice_cnt는 초기값을 3으로 설정해야한다는 것과 모서리 부분은 초기값을 2로 설정하거나 아예 제외시켜야 한다는 것이다.)