### PR TITLE
yoonhye / 2월 4주차 수요일 / 1문제

### DIFF
--- a/yoonhye/BAEKJOON/[BOJ] ZOAC4.py
+++ b/yoonhye/BAEKJOON/[BOJ] ZOAC4.py
@@ -1,13 +1,6 @@
-from collections import deque
-
 H, W, N, M = map(int, input().split())
 
 one_row_people = (W//(1+M)) + 1 if W%(1+M) != 0 else W//(1+M)
 line = (H//(N+1)) + 1 if H % (N+1) != 0 else H//(N+1)
-
-if line == 0:
-    line = 1
-if one_row_people == 0:
-    one_row_people = 1
 
 print(one_row_people * line)

--- a/yoonhye/BAEKJOON/[BOJ] ZOAC4.py
+++ b/yoonhye/BAEKJOON/[BOJ] ZOAC4.py
@@ -1,0 +1,13 @@
+from collections import deque
+
+H, W, N, M = map(int, input().split())
+
+one_row_people = (W//(1+M)) + 1 if W%(1+M) != 0 else W//(1+M)
+line = (H//(N+1)) + 1 if H % (N+1) != 0 else H//(N+1)
+
+if line == 0:
+    line = 1
+if one_row_people == 0:
+    one_row_people = 1
+
+print(one_row_people * line)


### PR DESCRIPTION
# [BOJ] ZOAC 4

**⏰ 0시간 33분  📌** 

- **`문제`**
    
    [[16719번: ZOAC](https://www.acmicpc.net/problem/16719)](https://www.acmicpc.net/problem/16719)
    
- **`접근`**
    - 처음에는 시간복잡도도 이차원 배열 크기의 최댓값이 50,000이라고 잘못 생각해서 그냥 다른 방법 더 생각 안 하고 자연스럽게 bfs 이용해서 자리 하나하나 앉게 하는걸 생각했었다. 그렇게 구현하니까 시간초과랑 메모리 초과가 났다. (이차원 배열 크기의 최댓값이 2,500,000,000이니까 당연한 결과였다..)
    - 참가자가 강의실에 최대로 들어가기 위해서는 최대한 빈틈없이 강의실을 채워야하므로, (0,0)부터 참가자가 앉기 시작한다고 생각해도 된다.
    - 한 참가자가 어떤 자리에 앉았다고 했을 때, 그 참가자가 차지하는 자리의 크기의 최솟값은 참가자가 앉은 자리를 한 꼭짓점으로 하는 길이가 가로 (1+M), 세로 (1+N)인 직사각형과 같다.(1은 참가자가 앉은 자리이다.)
        
       <img width="283" alt="스크린샷 2024-02-23 오후 5 08 14" src="https://github.com/cotepractice/CodingTest-Solution/assets/72440759/59676d98-7d0a-4798-bba1-ce9e1ed64695">

        
        예시 그림으로 치면 (0,0)에 앉은 참가자가 차지하는 자리의 크기는 빨간색으로 표시한 직사각형과 같다.
        
    - 따라서 한 행에 앉을 수 있는 참가자의 최대 인원 수는 한 행에 길이 (1+M)을 남김 없이 넣는 것과 같으므로, 한 행의 크기(W)를 (1+M)으로 나눈 값을 반올림 한 것과 같다. (반올림하는 이유는 마지막에 위치하는 참가자는 오른쪽에 자리를 비우지 않아도 되므로 (1+M)을 채우고 남는 칸에 아무데나 앉아도 되기 때문이다.)
    - 또한 이차원 배열 안에 그러한 행이 최대로 들어가기 위해서는 한 열(column)에 길이 (1+N)이 최대로 들어가는 것과 같으므로, 한 열의 크기(H)를 (1+N)으로 나눈 값을 반올림 한 것과 같다. (반올림 하는 이유는 위에서의 이유와 동일하다)
    - 최종적으로 강의실이 수용할 수 있는 최대 인원 수는 위에서 구한 두 값을 곱한 것과 같다. `(한 행에 들어갈 수 있는 참가자의 최대 인원 수) * (그러한 행 개수의 최댓값)`
- **`구현`**
    - 반올림 한 값은 math.ceil을 이용하여 구할 수도 있다. (++ 다시 보니 내 코드에서 math.ceil을 이용하면 if, else문은 없어도 된다!)