### PR TITLE
yoonhye / 3월 2주차 월요일 / 1문제

### DIFF
--- a/yoonhye/PROGRAMMERS/[PGS] 등굣길.py
+++ b/yoonhye/PROGRAMMERS/[PGS] 등굣길.py
@@ -1,33 +1,26 @@
 # (1,1)부터 시작.
 # 오른쪽과 아래족으로만 움직여 집에서 학교까지 갈 수 있는 최단경로의 개수를 1,000,000,007로 나눈 나머지 return
 # 좌표의 행열을 바꿔서 생각해야함.
+# dp[i][j] = dp[i][j-1] + dp[i-1][j]
+
 from collections import deque
 
 
 def solution(m, n, puddles):
     board = [[0 for _ in range(m)] for _ in range(n)]  # n행 m열
     dp = [[0 for _ in range(m)] for _ in range(n)]
-    visited = [[0 for _ in range(m)] for _ in range(n)]
-    d = [(0, 1), (1, 0)]  # 오른쪽, 아래쪽
+
     for y, x in puddles:
         board[x - 1][y - 1] = 1  # 물에 잠긴 지역
 
-    queue = deque([(0, 0)])
-
     dp[0][0] = 1
 
-    while (queue):
-        x, y = queue.popleft()
-        if visited[x][y] == 1:
-            continue
-        visited[x][y] = 1
-
-        for dx, dy in d:
-            nx, ny = x + dx, y + dy
-            if nx < 0 or ny < 0 or nx >= n or ny >= m:
-                continue
-            if board[nx][ny] == 0:
-                dp[nx][ny] += dp[x][y]
-                queue.append((nx, ny))
+    for i in range(n):
+        for j in range(m):
+            if board[i][j] == 0:
+                if 0 <= i - 1 < n:
+                    dp[i][j] += dp[i - 1][j]
+                if 0 <= j - 1 < m:
+                    dp[i][j] += dp[i][j - 1]
     print(dp)
     return dp[n - 1][m - 1] % 1000000007

--- a/yoonhye/PROGRAMMERS/[PGS] 등굣길.py
+++ b/yoonhye/PROGRAMMERS/[PGS] 등굣길.py
@@ -1,0 +1,33 @@
+# (1,1)부터 시작.
+# 오른쪽과 아래족으로만 움직여 집에서 학교까지 갈 수 있는 최단경로의 개수를 1,000,000,007로 나눈 나머지 return
+# 좌표의 행열을 바꿔서 생각해야함.
+from collections import deque
+
+
+def solution(m, n, puddles):
+    board = [[0 for _ in range(m)] for _ in range(n)]  # n행 m열
+    dp = [[0 for _ in range(m)] for _ in range(n)]
+    visited = [[0 for _ in range(m)] for _ in range(n)]
+    d = [(0, 1), (1, 0)]  # 오른쪽, 아래쪽
+    for y, x in puddles:
+        board[x - 1][y - 1] = 1  # 물에 잠긴 지역
+
+    queue = deque([(0, 0)])
+
+    dp[0][0] = 1
+
+    while (queue):
+        x, y = queue.popleft()
+        if visited[x][y] == 1:
+            continue
+        visited[x][y] = 1
+
+        for dx, dy in d:
+            nx, ny = x + dx, y + dy
+            if nx < 0 or ny < 0 or nx >= n or ny >= m:
+                continue
+            if board[nx][ny] == 0:
+                dp[nx][ny] += dp[x][y]
+                queue.append((nx, ny))
+    print(dp)
+    return dp[n - 1][m - 1] % 1000000007


### PR DESCRIPTION
# [PGS] 등굣길

**⏰ 0시간 50분  📌DP, BFS** 

- **`문제`**
    
    (https://school.programmers.co.kr/learn/courses/30/lessons/42898)
    
- **`접근`**
    - 물에 잠긴 지역을 피해서 집에서 학교까지 갈 수 있는 경로 중 최단 경로의 개수를 구하는 문제이다.
    - 이 문제는 특이하게 mxn 크기의 격자에서 m이 행, n이 열이 아니라 n이 행, m이 열이고 좌표값도 일반적인 이차원 배열과 달라서 주의해야 한다.
    - `dp[i][j]` : (0,0)에서 (i,j)까지 갈 수 있는 최단 경로의 개수
    - 처음에는 BFS를 이용해서 dp 값을 채워나갔다. (0,0)에서 출발해서 오른쪽, 아래쪽으로 이동하면서 `이동할 좌표의 dp값(dp[nx][ny])`에 `현재 위치한 좌표의 dp값(dp[x][y])`을 더해나가는 형식으로 구현하였다.
    - 그런데 BFS를 이용하면 중복 확인하는 좌표가 존재할 수밖에 없는데, 이 문제에서는 굳이 이렇게 할 필요가 없다는 것을 깨달았다. **이 문제에서는 오른쪽과 아래쪽으로만 움직일 수 있기 때문에 배열을 차례대로 순회할 때 뒤에 오는 dp값이 앞서 구한 dp값에 영향을 주지 않는다. 따라서 배열을 (0,0)부터 (n-1,m-1)까지 순서대로 한 번씩만 돌아도 dp값을 구할 수 있다.** 이렇게 dp값을 구하면 훨씬 더 빠른 속도로 결과값을 구할 수 있다.
        - **`dp[i][j] = dp[i][j-1] + dp[i-1][j]`**
- **`구현`**
    - 정확성은 다 통과되는데 효율성은 다 실패가 뜨길래 처음엔 시간이나 메모리 문제인줄 알아서 어디가 틀린건지 찾는데 한참 걸렸다. 문제에서 최단경로의 개수를 1,000,000,007로 나눈 나머지를 return 하라고 했었는데, 나머지가 아니라 그냥 최단경로의 개수를 return해서 틀린거였다. 문제 조건을 잘 읽도록 하자!!
