### PR TITLE
yoonhye / 4월 2주차 수요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[CODETREE] 메이즈 러너.py
+++ b/yoonhye/SAMSUNG/[CODETREE] 메이즈 러너.py
@@ -1,0 +1,153 @@
+# (1,1)부터 시작
+# 벽은 회전할 때 내구도가 1씩 깎이며, 내구도가 0이 되면 빈 칸으로 변경된다.
+# 모든 참가자는 동시에 움직인다.
+# 우선순위 : 상하
+# 이동을 끝낸 후, 한 명 이상의 참가자와 출구를 포함한 가장 작은 정사각형을 잡는다. 더 위쪽에 있을 수록, 더 왼쪽에 있을수록 우선됨.
+# 선택된 정사각형은 시계방향으로 90도 회전. 회전된 벽은 내구도가 1씩 깎인다.
+
+# 최단거리 반환 함수
+def shortest_distance(x1, y1, x2, y2):
+    return abs(x1 - x2) + abs(y1 - y2)
+
+
+# 참가자 이동 함수
+def move(ex, ey):
+    global move_cnt, N
+    delta = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+    new_participant = []
+    for x, y in participant:
+        d = shortest_distance(x, y, ex, ey)
+        mx, my = x, y
+        for dx, dy in delta:
+            nx, ny = x + dx, y + dy
+            if nx < 0 or ny < 0 or nx >= N or ny >= N or board[nx][ny] > 0:
+                continue
+
+            if (nx, ny) == (ex, ey):
+                move_cnt += 1
+                mx, my = nx, ny
+                break
+            elif shortest_distance(nx, ny, ex, ey) < d:
+                d = shortest_distance(nx, ny, ex, ey)
+                mx, my = nx, ny
+
+        if (mx, my) != (x, y) and (mx, my) != (ex, ey):  # 탈출이 아닌 이동을 했으면
+            new_participant.append((mx, my))
+            move_cnt += 1
+        elif (mx, my) == (x, y):  # 이동을 안 했으면
+            new_participant.append((mx, my))
+
+    return new_participant
+
+
+# 정사각형 한 변의 길이를 찾는 함수
+def find_length(x1, y1, x2, y2):
+    x1x2 = abs(x1 - x2)
+    y1y2 = abs(y1 - y2)
+
+    if x1x2 < y1y2:
+        return (y1y2 + 1, "상하", y1y2 - x1x2)  # 정사각형 한 변의 길이, 정사각형이 되기 위해 늘려야 하는 방향, 늘려야 하는 길이
+    elif x1x2 > y1y2:
+        return (x1x2 + 1, "좌우", x1x2 - y1y2)
+    else:  # x1x2 == y1y2. (x1, y1), (x2, y2)가 정사각형의 꼭짓점이라서 정사각형을 만들 필요가 없음
+        return (x1x2 + 1, "", 0)
+
+
+# 가장 작은 정사각형 찾는 함수
+def find_smallest_square(ex, ey):
+    sn = 11
+    sr, sc = 11, 11
+    for x, y in participant:
+        n, direction, l = find_length(x, y, ex, ey)  # 정사각형 한 변의 길이
+        if n <= sn:
+            r, c = min((x, y), (x, ey), (ex, y), (ex, ey))
+            if direction == "상하":
+                for _ in range(l):
+                    if r - 1 >= 0:
+                        r -= 1
+                    else:
+                        break
+            elif direction == "좌우":
+                for _ in range(l):
+                    if c - 1 >= 0:
+                        c -= 1
+                    else:
+                        break
+
+            if n < sn:
+                sn = n
+                sr, sc = r, c
+            elif n == sn and (r, c) < (sr, sc):
+                sr, sc = r, c
+    return sn, sr, sc
+
+
+# 회전
+def rotate(arr):
+    n = len(arr)
+    new_arr = [[0 for _ in range(n)] for _ in range(n)]
+    k = n - 1
+    for i in range(n):
+        lst = arr[i][:]
+        for j in range(n):
+            new_arr[j][k] = lst[j]
+        k -= 1
+    return new_arr
+
+
+# 회전할 정사각형 추출 후 회전
+def maze_rotate(n, r, c):
+    new_board = []
+    for i in range(r, r + n):
+        lst = []
+        for j in range(c, c + n):
+            lst.append(board[i][j])
+        new_board.append(lst)
+    new_board = rotate(new_board)
+
+    for i in range(r, r + n):
+        for j in range(c, c + n):
+            if new_board[i - r][j - c] > 0:  # 벽이면 내구도 1 감소
+                new_board[i - r][j - c] -= 1
+            elif new_board[i - r][j - c] == -1:  # 출구인 경우
+                ex, ey = i, j
+            board[i][j] = new_board[i - r][j - c]
+
+    # 참가자 위치 회전
+    for i in range(len(participant)):
+        x, y = participant[i]
+        if r <= x <= r + n - 1 and c <= y <= c + n - 1:
+            participant[i] = (r + (y - c), (c + n - 1) - (x - r))
+
+    return (ex, ey)
+
+
+def pretty_print():
+    global N
+    for i in range(N):
+        print(board[i])
+
+
+N, M, K = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(N)]
+participant = []
+for i in range(M):
+    a, b = map(int, input().split())
+    participant.append((a - 1, b - 1))
+
+ex, ey = map(int, input().split())
+ex, ey = ex - 1, ey - 1  # 출구의 좌표
+board[ex][ey] = -1
+
+move_cnt = 0  # 참가자들의 이동 거리 합
+
+for _ in range(K):
+    participant = move(ex, ey)
+    if not participant:  # 참가자가 모두 탈출함
+        break
+
+    n, r, c = find_smallest_square(ex, ey)
+    ex, ey = maze_rotate(n, r, c)
+
+print(move_cnt)
+print(ex + 1, ey + 1)


### PR DESCRIPTION
# [ETC] 메이즈러너

**⏰ 4시간 00분  📌구현**

- **`문제`**
    
    [[코드트리 | 코딩테스트 준비를 위한 알고리즘 정석](https://www.codetree.ai/training-field/frequent-problems/problems/maze-runner/description?page=1&pageSize=20)](https://www.codetree.ai/training-field/frequent-problems/problems/maze-runner/description?page=1&pageSize=20)
    
- **`접근`**
    - 조건에 맞게 구현하면 되는데, 가장 작은 정사각형을 찾고 회전시키는 부분이 어려운 부분인 것 같다.
    - 가장 작은 정사각형 찾기
        - 먼저, 모든 참가자에 대하여 출구와 각 참가자의 위치를 꼭짓점으로 하는 가장 작은 직사각형을 찾는다. 출구와 참가자의 위치를 꼭짓점으로 하는 사각형은 총 3가지의 유형이 있는데, **1. 가로가 넓은 경우(상하로 넓혀가며 정사각형을 만들어야 한다.)** **2. 세로가 넓은 경우(좌우로 넓혀가면서 정사각형을 만들어야 한다.)** **3. 출구와 참가자의 위치가 정사각형의 꼭짓점이 되는 경우(이미 가장 작은 정사각형이므로 정사각형을 만들지 않아도 된다.)** 가 있다.
        - 그 직사각형의 긴 변의 길이가 해당 참가자 기준 가장 작은 정사각형의 한 변의 길이가 되고, 정사각형은 직사각형을 포함한다.
        - 직사각형의 모든 꼭짓점을 구하고, 가장 작은 좌표값을 찾으면 그 좌표값이 곧 직사각형의 왼쪽 상단 꼭짓점이 된다. 사각형에서 대각선상에 위치하는 꼭짓점의 정보를 알고 있기 때문에 모든 꼭짓점을 구하는 것은 간단하다. 두 꼭짓점의 좌표가 `(x1, y1)`, `(x2, y2)`라면 나머지 꼭짓점은 `(x1, y2)`, `(x2, y1)`이기 때문이다.
        - 직사각형의 왼쪽 상단 꼭짓점을 사각형의 유형에 따라 위쪽 혹은 왼쪽으로 옮기면 해당 참가자의 위치와 출구를 포함한 가장 작은 정사각형의 좌상단 좌표를 찾을 수 있다.
    - 회전 시키기
        - 처음에는 보드 내에서 정사각형의 좌표 범위만 회전시키는 방법을 생각해서 복잡하게 느껴졌다.
        - 그러다가 아예 정사각형 배열을 따로 만들어서 그 배열 전체를 회전시킨 후, 기존 보드에 갖다 붙이는 방법을 떠올렸고 그렇게 하니까 훨씬 간단해졌다.
    - tc 6번에서 오류나길래 뭐 때문에 오류났는지 찾느라 2시간이나 걸렸다.. 근데 원인이 `find_smallest_square()` 함수에서 (sr,sc)라고 적어야하는데 (sr,sr) 이렇게 오타가 나서 그런거였다. ㅜㅜㅜ
- **`구현`**
    - 주의할 점은, 회전할 때 판만 이동시키는 것이 아니라 참가자의 위치도 변경해줘야 한다는 점이다. 이 부분을 작년에 이 문제를 풀었을 때도 놓쳤었는데 똑같이 놓쳤다. 주의하자!
    - (1,1)부터 시작하는데 나는 (0,0)으로 두는 경우, 최종적으로 결과값 return할 때 좌표에 +1, +1 해주는 것 잊지 말자!!