### PR TITLE
yoonhye / 4월 2주차 금요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[CODETREE] 코드트리 채점기.py
+++ b/yoonhye/SAMSUNG/[CODETREE] 코드트리 채점기.py
@@ -3,53 +3,63 @@
 # 채점 대기 큐에 있는 task 중 정확히 u와 일치하는 url이 단 하나라도 존재하면 큐에 추가 X
 
 import heapq
-from collections import deque
-from collections import defaultdict
 
-#채점 요청 200
+# 채점 요청 200
 def request(t, p, url):
+    global tasks
     domain, id = url.split('/')
     if url not in waiting_queue_url:
-        heapq.heappush(waiting_queue, (p, t, domain, id))
+        if waiting_queue.get(domain) == None:
+            waiting_queue[domain] = []
+            heapq.heapify(waiting_queue[domain])
+        heapq.heappush(waiting_queue[domain], (p, t, domain, id))
         waiting_queue_url.add(url)
+        tasks += 1
 
-#채점 시도 300
+
+# 채점 시도 300
 def try_judging(T):
-    if not judger:  #쉬고 있는 채점기가 없는 경우 요청 무시
+    global tasks
+    if not judger:  # 쉬고 있는 채점기가 없는 경우 요청 무시
         return
 
-    #해당 task의 도메인이 현재 채점을 진행중인 도메인 중 하나라면 불가능
-    #해당 task와 일치하는 도메인에 대해 가장 최근에 진행된 채점 시작 시간이 start, 종료 시간이 start+gap이었고,
-    #현재 시간 t가 start+3*gap 보다 작으면 채점 불가
+    # 해당 task의 도메인이 현재 채점을 진행중인 도메인 중 하나라면 불가능
+    # 해당 task와 일치하는 도메인에 대해 가장 최근에 진행된 채점 시작 시간이 start, 종료 시간이 start+gap이었고,
+    # 현재 시간 t가 start+3*gap 보다 작으면 채점 불가
 
-    can_not_judge = []
-    success = False
-    while(waiting_queue):
-        p, t, domain, id = heapq.heappop(waiting_queue)
+    res_p, res_t, res_domain = 500000, 500000, ""
+    for domain in waiting_queue.keys():
         if domain in judging_domain:
-            can_not_judge.append((p,t,domain,id))
             continue
         if history.get(domain) != None:
             start, end = history[domain]
-            gap = end-start
-            if T < (start + 3*gap):
-                can_not_judge.append((p, t, domain, id))
+            gap = end - start
+            if T < (start + 3 * gap):
                 continue
-        success = True
-        break
+        p, t, d, id = waiting_queue[domain][0]
+        if p < res_p:  # 우선순위가 높음
+            res_p, res_t, res_domain = p, t, domain
+        elif p == res_p:
+            if t < res_t:  # 들어온 시간이 더 빠름
+                res_p, res_t, res_domain = p, t, domain
 
-    if success: #채점 가능한 task가 단 하나라도 있다면
+    if res_domain != "":  # 채점 가능한 task가 단 하나라도 있다면
+        tasks -= 1
+        p, t, domain, id = heapq.heappop(waiting_queue[res_domain])
+
+        # 이거 안 해주면 key가 남아있어서 위에서 waiting_queue[domain][0] 할 때 런타임 에러남
+        if waiting_queue[res_domain] == []:
+            del waiting_queue[res_domain]
+
         n = heapq.heappop(judger)
-        judging[n] = (T,domain,id)
+        judging[n] = (T, domain, id)
         judging_domain.add(domain)
-        url = domain+"/"+id
+
+        url = domain + "/" + id
         waiting_queue_url.remove(url)
 
-    for lst in can_not_judge:
-        heapq.heappush(waiting_queue, lst)
 
-
-#채점 종료 400
+# 채점 종료 400
 def finish(t, J_id):
     if judging.get(J_id) != None:
         start, domain, id = judging[J_id]
@@ -58,18 +68,20 @@ def finish(t, J_id):
         judging_domain.remove(domain)
         heapq.heappush(judger, J_id)
 
-#채점 대기 큐 조회 500
+
+# 채점 대기 큐 조회 500
 def get_waiting_queue():
-    print(len(waiting_queue))
+    global tasks
+    print(tasks)
+
 
 Q = int(input())
 num, N, u0 = map(str, input().split())
 N = int(N)
-judger = [int(i) for i in range(1,N+1)]
+judger = [int(i) for i in range(1, N + 1)]
 heapq.heapify(judger)
 
-waiting_queue = []
-heapq.heapify(waiting_queue)
+waiting_queue = dict()
 waiting_queue_url = set()
 
 judging = dict()
@@ -77,7 +89,9 @@ judging_domain = set()
 
 history = dict()
 
-#코드트리 채점기 준비
+tasks = 0
+
+# 코드트리 채점기 준비
 request(0, 1, u0)
 
 for _ in range(Q - 1):
@@ -93,4 +107,3 @@ for _ in range(Q - 1):
         finish(t, J_id)
     else:
         get_waiting_queue()
-

--- a/yoonhye/SAMSUNG/[CODETREE] 코드트리 채점기.py
+++ b/yoonhye/SAMSUNG/[CODETREE] 코드트리 채점기.py
@@ -1,0 +1,96 @@
+# url : 도메인/문제ID
+# 0초에 채점 우선순위가 1이면서 url이 u0인 초기 문제에 대한 채점 요청이 들어옴
+# 채점 대기 큐에 있는 task 중 정확히 u와 일치하는 url이 단 하나라도 존재하면 큐에 추가 X
+
+import heapq
+from collections import deque
+from collections import defaultdict
+
+#채점 요청 200
+def request(t, p, url):
+    domain, id = url.split('/')
+    if url not in waiting_queue_url:
+        heapq.heappush(waiting_queue, (p, t, domain, id))
+        waiting_queue_url.add(url)
+
+#채점 시도 300
+def try_judging(T):
+    if not judger:  #쉬고 있는 채점기가 없는 경우 요청 무시
+        return
+
+    #해당 task의 도메인이 현재 채점을 진행중인 도메인 중 하나라면 불가능
+    #해당 task와 일치하는 도메인에 대해 가장 최근에 진행된 채점 시작 시간이 start, 종료 시간이 start+gap이었고,
+    #현재 시간 t가 start+3*gap 보다 작으면 채점 불가
+
+    can_not_judge = []
+    success = False
+    while(waiting_queue):
+        p, t, domain, id = heapq.heappop(waiting_queue)
+        if domain in judging_domain:
+            can_not_judge.append((p,t,domain,id))
+            continue
+        if history.get(domain) != None:
+            start, end = history[domain]
+            gap = end-start
+            if T < (start + 3*gap):
+                can_not_judge.append((p, t, domain, id))
+                continue
+        success = True
+        break
+
+    if success: #채점 가능한 task가 단 하나라도 있다면
+        n = heapq.heappop(judger)
+        judging[n] = (T,domain,id)
+        judging_domain.add(domain)
+        url = domain+"/"+id
+        waiting_queue_url.remove(url)
+
+    for lst in can_not_judge:
+        heapq.heappush(waiting_queue, lst)
+
+
+#채점 종료 400
+def finish(t, J_id):
+    if judging.get(J_id) != None:
+        start, domain, id = judging[J_id]
+        history[domain] = (start, t)
+        del judging[J_id]
+        judging_domain.remove(domain)
+        heapq.heappush(judger, J_id)
+
+#채점 대기 큐 조회 500
+def get_waiting_queue():
+    print(len(waiting_queue))
+
+Q = int(input())
+num, N, u0 = map(str, input().split())
+N = int(N)
+judger = [int(i) for i in range(1,N+1)]
+heapq.heapify(judger)
+
+waiting_queue = []
+heapq.heapify(waiting_queue)
+waiting_queue_url = set()
+
+judging = dict()
+judging_domain = set()
+
+history = dict()
+
+#코드트리 채점기 준비
+request(0, 1, u0)
+
+for _ in range(Q - 1):
+    req = list(map(str, input().split()))
+    if req[0] == "200":
+        t, p, url = int(req[1]), int(req[2]), req[3]
+        request(t, p, url)
+    elif req[0] == "300":
+        t = int(req[1])
+        try_judging(t)
+    elif req[0] == "400":
+        t, J_id = int(req[1]), int(req[2])
+        finish(t, J_id)
+    else:
+        get_waiting_queue()
+


### PR DESCRIPTION
# [ETC] 코드트리 채점기

**⏰ 2시간 50분  📌구현, heap**

- **`문제`**
    
    [[코드트리 | 코딩테스트 준비를 위한 알고리즘 정석](https://www.codetree.ai/training-field/frequent-problems/problems/codetree-judger/description?page=1&pageSize=20)](https://www.codetree.ai/training-field/frequent-problems/problems/codetree-judger/description?page=1&pageSize=20)
    
- **`접근`**
    - 자료구조를 적절하게 사용해서 시간복잡도를 줄이는 것이 관건인 문제이다. 구현 자체는 쉽게 할 수 있지만 어떻게 구현해야 시간복잡도를 줄일 수 있는지 생각하는게 어려운 문제였다.
    - 처음에 구현했을 때 시간초과가 발생했는데, 채점 시도 함수에서 시간초과가 발생한 것 같다. 내 코드에서 시간 초과가 날 수 있는 상황을 생각해 봤는데 다음과 같다.
        - waiting_queue에 10,000개가 있고, 1개가 채점중이고, 1개의 채점기가 남았다고 하자. 채점중인 도메인은 ‘codetree.ai’이고 waiting_queue에는 도메인이 ‘codetree.ai’ 밖에 없다면, 20,000번 연속으로 채점 시도 요청이 들어왔을 때 `waiting_queue의 길이 * 요청 횟수`만큼 즉, 200,000,000번(2억)의 연산을 수행하게 된다.
        - 위와 같은 상황이 발생하는 이유는 최악의 경우 waiting_queue에 있는 모든 원소를 `heappop()`을 통해 꺼내고 `heappush()`를 통해 넣기 때문이다. (* 참고 : `heappop()`의 시간복잡도는 **O(logN)**, `heappush()`의 시간복잡도는 **O(logN)** 이다. 여기서 중요한건 heappop, heappush를 이용한다는 것보다 waiting_queue에 있는 모든 원소를 순회하기 때문에 시간 초과가 발생한다는 것이다.)
        - 명령의 수 Q의 범위가 1≤Q≤50,000 이므로 대충 waiting_queue에 30,000개의 원소가 들어있고, 채점 시도 과정을 총 10,000번 한다고만 해도 3억번의 연산을 해야하므로 당연히 시간초과가 발생할 수밖에 없다.
    - 시간 초과를 피하기 위해 waiting_queue에 원소를 저장할 때 도메인별로 분류하기로 했다. **1 ≤ 주어지는 서로 다른 도메인의 수 ≤ 300** 이므로 모든 원소를 순회하더라도 시간 초과가 발생하지 않는다.
    - waiting_queue를 딕셔너리로 바꿔주었으며, key를 domain, vlaue를 해당 도메인을 가진 task 정보 힙으로 구성해주었다. 이렇게 하면 채점 시도를 할 때 waiting_queue에 있는 모든 도메인을 돌면서 채점 불가능한 도메인을 가진 task들을 빠르게 pass할 수 있으며, 채점 가능한 task를 찾을 때는 heap의 특성을 이용하여 쉽게 찾을 수 있다.