### PR TITLE
yoonhye / 4월 3주차 월요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/[CODETREE] 마법의 숲 탐색.py
+++ b/yoonhye/SAMSUNG/[CODETREE] 마법의 숲 탐색.py
@@ -1,0 +1,83 @@
+def move_down(x, y, d):
+    global L
+    if x + 2 >= L or board[x + 2][y] or board[x + 1][y - 1] or board[x + 1][y + 1]:
+        return move_left(x, y, d)
+    return (x + 1, y, d)
+
+
+def move_left(x, y, d):
+    global L
+    if y - 2 < 0 or board[x][y - 2] or board[x - 1][y - 1] or board[x + 1][y - 1]:
+        return move_right(x, y, d)
+    if x + 2 >= L or board[x + 2][y - 1] or board[x + 1][y - 2] or board[x + 1][y]:
+        return move_right(x, y, d)
+    d -= 1
+    if d < 0:
+        d = d + 4
+    return (x + 1, y - 1, d)
+
+
+def move_right(x, y, d):
+    global L, C
+    if y + 2 >= C or board[x][y + 2] or board[x - 1][y + 1] or board[x + 1][y + 1]:
+        return False
+    if x + 2 >= L or board[x + 2][y + 1] or board[x + 1][y + 2] or board[x + 1][y]:
+        return False
+
+    d = (d + 1) % 4
+    return (x + 1, y + 1, d)
+
+
+def get_score(i):
+    global L, C
+    stack = [i]
+    visited = set({i})
+    max_score = 0
+    while (stack):
+        n = stack.pop()
+        x, y, d = robot[n]
+        max_score = max(max_score, x + 1)
+        ex, ey = x + delta[d][0], y + delta[d][1]
+        for dx, dy in delta:
+            nx, ny = ex + dx, ey + dy
+            if nx < 0 or ny < 0 or nx >= L or ny >= C or board[nx][ny] == 0:
+                continue
+            if board[nx][ny] != n and board[nx][ny] not in visited:
+                stack.append(board[nx][ny])
+                visited.add(board[nx][ny])
+
+    return max_score - 2
+
+
+R, C, K = map(int, input().split())
+L = R + 3
+board = [[0 for _ in range(C)] for _ in range(L)]
+
+
+#상우하좌 => 0~3
+req = []
+robot = dict()
+score = 0
+delta = [(-1, 0), (0, 1), (1, 0), (0, -1)]
+for _ in range(K):
+    c, d = map(int, input().split())
+    req.append((c-1, d))
+
+for i in range(1, K + 1):
+    x, y, d = 1, req[i - 1][0], req[i - 1][1]
+    while (1):
+        result = move_down(x, y, d)
+        if result == False:
+            break
+        x, y, d = result
+
+    if x <= 3:
+        board = [[0 for _ in range(C)] for _ in range(L)]
+        continue
+    board[x][y] = i
+    for j in range(4):
+        board[x + delta[j][0]][y + delta[j][1]] = i
+
+    robot[i] = (x, y, d)
+    score += get_score(i)
+print(score)

--- a/yoonhye/SAMSUNG/[CODETREE] 왕실의 기사 대결.py
+++ b/yoonhye/SAMSUNG/[CODETREE] 왕실의 기사 대결.py
@@ -1,0 +1,148 @@
+# (1,1)부터 시작. => 나는 (0,0)부터 시작할거니까 주의하기
+# 기사의 위치 (r,c)를 좌측 상단으로 하는 hXw 크기의 직사각형.
+# 밀려난 기사들은 해당 기사가 이동한 곳에서 wxh 직사각형 내에 놓여 있는 함정의 수만큼 피해를 입는다.
+# 피해를 받은 만큼 체력이 깎이게 되며, 현재 체력 이상의 대미지를 받을 경우 체스판에서 사라짐.
+# 명령을 받은 기사는 피해 X. 기사들은 모두 밀린 이후에 대미지를 입는다.
+# 생존한 기사들이 총 받은 대미지의 합 return
+
+
+# 왼쪽으로 미는 경우
+# (r,c) ~ (r+h-1, c) => 얘네를 밀었을 때 밀 수 있으면 가능
+
+# 오른쪽
+# (r,c+w-1) ~ (r+h-1, c+w-1)
+
+# 위쪽
+# (r, c) ~ (r, c+w-1)
+
+# 아래쪽
+# (r+h-1, c) ~ (r+h-1, c+w-1)
+
+
+def check_move(n, d, can_move):
+    global L
+    r, c, h, w, k = info[n]
+
+    # [열이 바뀜, (고정값, 바뀌는 값)] or [행이 바뀜, (바뀌는 값, 고정값)]
+    loop_range = [["c", (0, w - 1)], ["r", (h - 1, w - 1)], ["c", (h - 1, w - 1)], ["r", (h - 1, 0)]]
+
+    dx, dy = delta[d]
+
+    other_knight = set()
+    nr, nc = r + loop_range[d][1][0], c + loop_range[d][1][1]
+    if loop_range[d][0] == "r":  # 열 고정, 행이 바뀜
+        for i in range(r, nr + 1):
+            x, y = i + dx, nc + dy
+            if x < 0 or y < 0 or x >= L or y >= L or board[x][y] == 2:
+                return False
+            if knight[x][y] != n and knight[x][y] > 0:  # 다른 기사가 있으면
+                other_knight.add(knight[x][y])
+
+    else:  # 행 고정, 열이 바뀜
+        for i in range(c, nc + 1):
+            x, y = nr + dx, i + dy
+            if x < 0 or y < 0 or x >= L or y >= L or board[x][y] == 2:
+                return False
+            if knight[x][y] != n and knight[x][y] > 0:  # 다른 기사가 있으면
+                other_knight.add(knight[x][y])
+
+    # 기사가 이동이 가능하다면 다음 기사도 이동이 되는지 확인
+    can_move.append(n)
+    for num in other_knight:
+        # 하나라도 이동이 불가능한 경우 전체 이동 불가능
+        if check_move(num, d, can_move) == False:
+            return False
+
+    return can_move
+
+
+def change_knight_board(n, d, t):
+    r, c, h, w, k = info[n]
+
+    # [열이 바뀜, (고정값, 바뀌는 값)] or [행이 바뀜, (바뀌는 값, 고정값)]
+    loop_range = [["c", (0, w - 1)], ["r", (h - 1, w - 1)], ["c", (h - 1, w - 1)], ["r", (h - 1, 0)]]
+
+    dx, dy = delta[d]
+
+    nr, nc = r + loop_range[d][1][0], c + loop_range[d][1][1]
+    if loop_range[d][0] == "r":  # 열 고정, 행이 바뀜
+        for i in range(r, nr + 1):
+            x, y = i, nc
+            if t == n:
+                x, y = x + dx, y + dy
+            knight[x][y] = t
+
+    else:  # 행 고정, 열이 바뀜
+        for i in range(c, nc + 1):
+            x, y = nr, i
+            if t == n:
+                x, y = x + dx, y + dy
+            knight[x][y] = t
+
+
+def damage(n):
+    r, c, h, w, k = info[n]
+    cnt = 0
+    for x in range(r, r + h):
+        for y in range(c, c + w):
+            if board[x][y] == 1:
+                cnt += 1
+    if k - cnt <= 0:
+        del info[n]
+        del init_damage[n]
+        for x in range(r, r + h):
+            for y in range(c, c + w):
+                knight[x][y] = 0
+    else:
+        info[n][-1] = k - cnt
+
+
+L, N, Q = map(int, input().split())
+
+# 0 : 빈 칸, 1 : 함정, 2: 벽
+board = [list(map(int, input().split())) for _ in range(L)]
+
+init_damage = dict()
+info = dict()
+knight = [[0 for _ in range(L)] for _ in range(L)]
+for i in range(1, N + 1):
+    r, c, h, w, k = map(int, input().split())
+    r, c = r - 1, c - 1
+    info[i] = [r, c, h, w, k]
+    init_damage[i] = k
+    for x in range(r, r + h):
+        for y in range(c, c + w):
+            knight[x][y] = i
+
+# 명령 : (i,d) => i번 기사에게 d 방향으로 한 칸 이동하라는 명령
+# 이미 사라진 기사의 번호가 주어질 수도 있다.
+# d : 0~3 => 상, 우, 하, 좌
+delta = [(-1, 0), (0, 1), (1, 0), (0, -1)]  # 상, 우, 하, 좌
+req = []
+for _ in range(Q):
+    i, d = map(int, input().split())
+    req.append((i, d))
+
+for i, d in req:
+    if info.get(i) == None:
+        continue
+    move_knights = check_move(i, d, [])
+    if move_knights == False:
+        continue
+    # 이동 가능한 기사들을 이동시킴
+    dx, dy = delta[d]
+
+    for n in move_knights[::-1]:
+        change_knight_board(n, d, n)
+        other_d = (d + 2) % 4
+        change_knight_board(n, other_d, 0)
+        info[n][0], info[n][1] = info[n][0] + dx, info[n][1] + dy
+    for n in move_knights[1:]:
+        damage(n)
+
+init_hp = sum(init_damage.values())
+final_hp = 0
+for n in info.keys():
+    final_hp += info[n][-1]
+
+print(init_hp - final_hp)


### PR DESCRIPTION
# [ETC] 마법의 숲 탐색

**⏰ 0시간 40분  📌구현, 시뮬레이션, BFS/DFS**

- **`문제`**
    
    [[코드트리 | 코딩테스트 준비를 위한 알고리즘 정석](https://www.codetree.ai/training-field/frequent-problems/problems/magical-forest-exploration/description?page=1&pageSize=20)](https://www.codetree.ai/training-field/frequent-problems/problems/magical-forest-exploration/description?page=1&pageSize=20)
    
- **`접근`**
    - 이 문제는 골렘의 이동과 정령의 이동을 처리하면 되는 문제이다. 골렘이 숲을 벗어난 상태에서 출발하고, 이동 후에도 몸의 일부가 숲을 벗어난 상태이면 숲을 초기화시켜야 한다. 그러므로 골렘의 길이(3)만큼 행을 늘려서 보드판을 (R+3)XC 형태로 구성하였다. 이렇게 하면 골렘이 항상 1행 c열에서 출발하도록 할 수 있고, 골렘이 이동을 끝냈을 때 행의 위치가 3이하인 경우
    - **`골렘의 이동`**
        - 아래로 이동할 수 있는지 확인 → 안되면 왼쪽, 아래로 이동할 수 있는지 확인 → 안되면 오른쪽, 아래로 이동할 수 있는지 확인
        - 위와 같은 절차를 밟아야하기 때문에 `move_down()`의 조건을 만족하지 못하면 `move_left()`를 실행하고, `move_left()`의 조건을 만족하지 못하면 `move_right()`를 실행하도록 하였다. `move_right()`의 조건도 만족하지 못하면 `False`를 반환하게 하였다.
        - 골렘이 성공적으로 이동했으면 골렘이 차지하고 있는 모든 칸에 번호값을 넣어준다. (정령의 이동을 처리할 때 어느 부분에 몇 번 골렘이 위치하고 있는지 확인하기 위함)
        - 그리고 따로 골렘의 정보를 저장해준다. 골렘의 정보를 저장하는 형태는 골렘의 번호를 Key로 하고 골렘의 가운데 좌표(x,y)와 출구의 방향을 Value로 하는 딕셔너리 형태이다.
    - **`정령의 이동`**
        - 골렘이 완전히 이동한 후 정령을 이동시킨다.
        - bfs, dfs 둘 다 가능하지만 난 dfs를 택했다.
        - 출구의 위치를 기준으로 상하좌우에 다른 골렘의 번호가 존재하면(0보다 큰 숫자) 해당 번호를 stack에 넣어주고 visited에도 넣어서 방문 처리를 해준다.
        - 정령이 이동 가능한 골렘으로 모두 이동하면서 행 번호의 최댓값을 구한다.