### PR TITLE
seoyeon / 6월 5주차 수요일 / 1문제

### DIFF
--- a/seoyeon/백준/삼성 SW 역량 테스트 기출/스타트와 링크_sol2.py
+++ b/seoyeon/백준/삼성 SW 역량 테스트 기출/스타트와 링크_sol2.py
@@ -21,6 +21,7 @@ def backTracking(depth, idx):
                 elif not visit[i] and not visit[j]:
                     link += graph[i][j]
         result = min(result, abs(start-link))
+        return
 
     for i in range(idx, N):
         if not visit[i]:

--- a/seoyeon/백준/삼성 SW 역량 테스트 기출/스타트와 링크_sol2.py
+++ b/seoyeon/백준/삼성 SW 역량 테스트 기출/스타트와 링크_sol2.py
@@ -1,0 +1,32 @@
+#백준 #14889 스타트와 링크
+#삼성 SW 역량 테스트 기출
+#알고리즘: 브루트포스&백트래킹
+
+N = int(input())
+graph = [[0 for _ in range(N)] for _ in range(N)]
+visit = [False for _ in range(N)]   #visit에 속하면 Start group
+result = float("inf")
+
+for i in range(N):
+    graph[i] = list(map(int, input().split()))
+
+def backTracking(depth, idx):
+    global result
+    if depth == N//2:
+        start, link = 0,0
+        for i in range(N):
+            for j in range(N):
+                if visit[i] and visit[j]:
+                    start += graph[i][j]
+                elif not visit[i] and not visit[j]:
+                    link += graph[i][j]
+        result = min(result, abs(start-link))
+
+    for i in range(idx, N):
+        if not visit[i]:
+            visit[i] = True
+            backTracking(depth+1,i+1)
+            visit[i] = False
+
+backTracking(0,0)
+print(result)


### PR DESCRIPTION
## [BOJ] 스타트와 링크 (Sol2)
#### ⏰ 측정X 📌 브루트포스&백트래킹 문제
### 문제
<https://www.acmicpc.net/problem/14889>

### 문제 해결
- **visit 리스트는 Start 팀인지 Link 팀인지 구분하는 역할**
  - visit==True인 경우 Start 팀, visti==False인 경우 Link 팀  
- backTracking 함수
  - 종결조건: depth==N//2인 경우(visit 리스트에서 True인 인덱스 수)
    - 이중 for문으로 i와 j가 모두 Start 팀인 경우와 모두 Link 팀인 경우 해당 팀에 점수 추가
    - 이중 for문이 끝난 후 기존의 최소 차이 값(result)와 현재 계산한 차이 값의 최솟값 구하기
    - 마지막에 return으로 아래 for문이 동작하지 않도록 함
  - for문으로 i를 현재 본인 인덱스인 idx 부터 N까지로 설정해 탐색
    - 본인(visit[i])을 Start 팀으로 설정 후 backTracking(depth+1, i+1)
      - 즉 본인을 Start팀으로 설정해 depth(인원 수)를 1 증가 한 후 본인 이후의 인덱스 탐색
    - 본인(visit[i])을 Link 팀으로 설정

### 피드백
- itertools 사용하지 않고 backtracking으로 해결해봄 !
- backTracking 재귀함수 실행 시 본인 이후(i+1)의 값을 idx로 설정하기 때문에 `if not visit[i]` 없어도 동작할 것으로 예상
  - 실제로 없앤 코드로 채점한 결과 동일하게 성공