### PR TITLE
seoyeon / 7월 1주차 수요일 / 2문제

### DIFF
--- a/seoyeon/프로그래머스/2024 KAKAO WINTER INTERNSHIP/도넛과 막대 그래프.py
+++ b/seoyeon/프로그래머스/2024 KAKAO WINTER INTERNSHIP/도넛과 막대 그래프.py
@@ -1,0 +1,114 @@
+#프로그래머스
+
+#1. 알고리즘 DFS 완전 탐색 => 정확도 4.5
+def graph(start,end,visited,edges,check):
+    global final_n
+    
+    if start>final_n:
+        final_n = start
+    elif end>final_n:
+        final_n = end
+        
+    #print("s",start,visited[start],"e",end,visited[end],check)
+    lst1 = []
+    lst2 = []
+    visited[start] += 1
+    
+    #도넛 그래프 종결 (N=1)
+    if start == end:
+        return 1
+    
+    #반복
+    if visited[end]==1:
+        if check==0:
+            return 1
+        else:
+            return 3
+    
+    #현재 end에서 이동할 정점 찾기. 다음 graph()
+
+    for i in range(len(edges)):
+        if edges[i][0]==end:
+            if visited[edges[i][1]] == 0:
+                lst1.append([edges[i][0], edges[i][1]])
+            else:
+                lst2.append([edges[i][0], edges[i][1]])
+    
+    if len(lst1)+len(lst2)==0:
+        visited[end] += 1
+        return 2
+    elif len(lst1)+len(lst2)==1:
+        if len(lst1)==1:
+            return graph(lst1[0][0], lst1[0][1], visited, edges, check)
+        else:
+            return graph(lst2[0][0], lst2[0][1], visited, edges, check)
+    else:
+        check = 1
+        if len(lst1)>=1:
+            return graph(lst1[0][0], lst1[0][1], visited, edges, check)
+        else:
+            return graph(lst2[0][0], lst2[0][1], visited, edges, check)
+
+def solution(edges):
+    visited = [0 for _ in range(len(edges)+1)]
+    global final_n 
+    max_n = 0
+    n_lst = [0 for _ in range(len(edges)+1)]
+    for i in range(len(edges)):
+        n_lst[edges[i][0]] += 1
+        if (n_lst[max_n] < n_lst[edges[i][0]]):
+            max_n = edges[i][0]
+    result_lst = [max_n,0,0,0]
+    
+    for k in range(len(edges)):
+        
+        if edges[k][0] == max_n:
+            continue
+        
+        if visited[edges[k][0]] == False:
+
+            result = graph(edges[k][0],edges[k][1],visited,edges,0)
+            #print("r",result)
+            if result==-1 or result == None:
+                return -1
+            result_lst[result] += 1
+            
+    for k in range(1, final_n+1):
+        if k!=max_n and visited[k] == 0:
+            print("k",k)
+            result_lst[2] += 1
+    
+    return result_lst
+
+final_n = 0
+
+#2. dictionary 사용 => 정확도 100\\\\\\\\\\\\\\\\\-
+
+def solution(edges):
+
+    dict = {}   #dict는 {a: [n,m]}으로 n은 나가는 간선 수, m은 들어가는 간선 수
+    
+    #들어오고 나가는 간선 수
+    for a,b in edges:
+        if not dict.get(a):
+            dict[a] = [0,0]
+        if not dict.get(b):
+            dict[b] = [0,0]
+        
+        dict[a][0] += 1
+        dict[b][1] += 1
+    
+    #간선 수에 따라 정점 선택 
+    answer = [0,0,0,0]
+    for key,cnt in dict.items():
+        if cnt[0]>=2 and cnt[1]==0:
+            answer[0] = key
+        elif cnt[0]==0 and cnt[1]>0:
+            answer[2] += 1
+        elif cnt[0]>=2 and cnt[1]>=2:
+            answer[3] += 1
+    
+    #도넛 모양 그래프는 전체 개수(생성된 정점은 모든 그래프의 개수만큼 나가는 간선 존재)에서 막대 모양과 8자 모양 그래프를 뺀 값
+    answer[1] = dict[answer[0]][0] - answer[2] - answer[3]
+    
+    return answer

--- a/seoyeon/프로그래머스/PCCE & PCCP/PCCP 기출문제2.py
+++ b/seoyeon/프로그래머스/PCCE & PCCP/PCCP 기출문제2.py
@@ -1,0 +1,194 @@
+# [PCCP 기출문제] 2번
+
+#1. BFS 사용 => 정확성:60.0, 효율성:0.0, 총 60.0/100.0
+from collections import deque
+
+def bfs(x,y,cnt,visited,land):
+    #print("x,y",x,y)
+    global n,m
+    Q = deque()
+    Q.append((x,y))
+
+    visited[x][y] = True
+    dx = [0,0,-1,1]
+    dy = [-1,1,0,0]
+    
+    while Q:
+        mx,my = Q.popleft()
+        cnt += 1
+        for k in range(4):
+            nx = mx+dx[k]
+            ny = my+dy[k]
+        
+            if 0<=nx<n and 0<=ny<m:
+                if visited[nx][ny] == False and land[nx][ny]==1:
+                    #print("nxny",nx,ny)
+                    Q.append((nx,ny))
+                    visited[nx][ny] = True
+                    #Q.append((nx,ny))
+    return cnt            
+    
+    
+def solution(land):
+    #land[n][m]
+    global n,m
+    n = len(land)
+    m = len(land[0])
+    #visited = [[False for _ in range(m+1)] for _ in range(n+1)]
+    
+    oil_amount = [0 for _ in range(m)]
+    for i in range(m):
+        visited = [[False for _ in range(m+1)] for _ in range(n+1)]
+        for j in range(n):
+            if land[j][i] == 1 and visited[j][i] == False:
+                amount = bfs(j,i,0,visited,land)
+                #print("amount",amount)
+                oil_amount[i] += amount
+            
+    #print(oil_amount)
+    answer = max(oil_amount)
+    return answer
+
+global n
+global m 
+
+#2. BFS 사용 => 정확성 60.0, 효율성 26.7, 합계 86.7/100
+from collections import deque
+
+def bfs(x,y,cnt,visited,land,comparison,compare):
+    global n,m
+    Q = deque()
+    Q.append((x,y))
+    lst = []
+
+
+    visited[x][y] = True
+    dx = [0,0,-1,1]
+    dy = [-1,1,0,0]
+    
+    while Q:
+        mx,my = Q.popleft()
+        lst.append((mx,my))
+        cnt += 1
+        for k in range(4):
+            nx = mx+dx[k]
+            ny = my+dy[k]
+        
+            if 0<=nx<n and 0<=ny<m:
+                if visited[nx][ny] == False and land[nx][ny]==1:
+                    Q.append((nx,ny))
+                    visited[nx][ny] = True
+    #print("lst",lst)
+    for k in range(len(lst)):
+        
+        land[lst[k][0]][lst[k][1]] = cnt
+        compare[lst[k][0]][lst[k][1]] = comparison
+            
+    return cnt            
+    
+    
+def solution(land):
+
+    global n,m
+    n = len(land)
+    m = len(land[0])
+    comparison = 0
+    visited = [[False for _ in range(m)] for _ in range(n)]
+    compare = [[-1 for _ in range(m)] for _ in range(n)]
+    
+    #석유 존재하는 모든 좌표에 석유양 표시 land[x][y]=AMOUNT
+    for i in range(m):
+        for j in range(n):
+            if land[j][i] == 1 and visited[j][i] == False:
+                bfs(j,i,0,visited,land,comparison,compare)
+                comparison += 1
+    
+    oil_amount = [0 for _ in range(m)]
+    #계산
+    for i in range(m):
+        amount = 0 
+        already = []
+        for j in range(n):
+            check = 0
+            #석유 없는 공간이면 패쓰
+            if compare[j][i] == -1:
+                continue
+            #석유 있으면 이미 계산한 것과 겹치는지 확인
+            for k in range(len(already)):
+                if compare[j][i] == already[k]:
+                    check = 1
+            if check == 0:
+                #겹치지 않을 때 
+                already.append(compare[j][i])
+                amount += land[j][i]
+        oil_amount[i] = amount
+    
+    answer = max(oil_amount)
+
+    return answer
+
+global n
+global m 
+global comparison
+
+#3. 정확성 60, 효율성 40, 합계 100
+#덩어리 분리 list가 아닌 set 사용해 중복 방지 
+
+from collections import deque
+
+def bfs(x,y,cnt,visited,land,comparison):
+    global n,m
+    Q = deque()
+    Q.append((x,y))
+    column_lst = []   
+
+    visited[x][y] = True
+    dx = [0,0,-1,1]
+    dy = [-1,1,0,0]
+    
+    while Q:
+        mx,my = Q.popleft()
+        column_lst.append(my)
+        cnt += 1
+        for k in range(4):
+            nx = mx+dx[k]
+            ny = my+dy[k]
+        
+            if 0<=nx<n and 0<=ny<m:
+                if visited[nx][ny] == 0 and land[nx][ny]==1:
+                    Q.append((nx,ny))
+                    visited[nx][ny] = True
+    
+    column_set = set(column_lst)        
+    return cnt, column_set    #해당 덩어리의 크기와 덩어리가 존재하는 columns       
+    
+    
+def solution(land):
+
+    global n,m
+    n = len(land)
+    m = len(land[0])
+    comparison = 1  #땅 비교. 1부터 점점 증가
+    visited = [[0 for _ in range(m)] for _ in range(n)]
+    oil_lst = []
+    oil_amount = [0 for _ in range(m)]
+    
+    #석유 존재하는 모든 좌표에 석유양 표시 land[x][y]=AMOUNT
+    for i in range(m):
+        for j in range(n):
+            if land[j][i] == 1 and visited[j][i] == 0:
+                size,columns = bfs(j,i,0,visited,land,comparison)
+                oil_lst.append([size, columns])
+                comparison += 1
+    
+    for k in range(len(oil_lst)):
+        for l in oil_lst[k][1]:
+            oil_amount[l] += oil_lst[k][0]
+
+    answer = max(oil_amount)
+
+    return answer
+
+global n
+global m 
+global comparison


### PR DESCRIPTION
## [PSG] 
#### ⏰ 측정X 📌 도넛과 막대 그래프
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/258711>

### 문제 해결
> `dictionary` 자료 구조 사용


나가는 간선과 들어오는 간선의 수로 graph 유형과 개수 확인 가능

- 하나의 graph 당 아래와 같은 간선 존재해 개수 측정 가능
1. **새롭게 생성된 정점** ⇒ 나가는 간선이 2개 이상, 들어오는 간선이 0개
2. **막대 모양 그래프** ⇒ 나가는 간선이 0개, 들어오는 간선이 1개
3. **8자 모양 그래프** ⇒ 나가는 간선이 2개, 들어오는 간선이 2개
4. **도넛 모양 그래프** ⇒ 모든 graph 수 - (막대 그래프 + 8자 그래프)
    - 도넛 모양 그래프의 경우 특징이 있는 정점이 존재하지 않아  모든 graph에서 다른 graph를 빼는 방식으로 풀이
    
### 피드백
- 처음에 간선 수로 새롭게 생성된 정점을 구하려 하였지만, dictionary를 생각하지 못 하고 list를 사용하는데 코드가 복잡해져 포기하고 dfs로 완전 탐색 도전
- dfs로 푸니 많은 테스트 케이스에서 시간 초과 발생
    - 처음 예제 2개는 맞았지만 정확도 4.5 ^^ ;;
- dictionary 자료구조를 오랜만에 사용해 사용 방법을 잊었다 😿

## [PSG] 석유 시추
#### ⏰ 2:00 📌 BFS 
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/250136>

### 문제 해결
1. BFS로 존재하는 석유의 양을 구하고 각 해당 석유에서의 column 좌표 반환
    1. 이때 column 좌표는 겹쳐도 한 번만 계산해야 되므로 **Set 사용**
2. 석유의 양과 column은 oil_lst에 [size, columns]로 저장
    1. columns는 set 형식
    2. oil_lst = [[8, (0,1,2,3,4)], […]] 와 같이 저장
3. oil_lst를 for문 돌려 column에 해당하는 석유의 양만큼 더해줌
    
    ```python
    for k in range(len(oil_lst)):
    	for l in oil_lst[k][1]:
    		oil_amount[l] += oil_lst[k][0]
    ```
    
4. oil_amount 중 가장 큰 값 찾아 반환
    
### 피드백
석유 덩어리를 구분해야 하는 것까지 인지했는데, 새로운 list에 석유 덩어리 번호를 넣어 저장하려 했음

- 이 경우 석유 번호를 또 for문으로 비교해야 하므로 효율성 측에서 시간 초과 발생

📍 Column을 중심으로 Set을 사용해 덩어리가 더해져야 하는 Column을 구하는 것이 인상 깊었음

- 중복 또는 불필요한 계산 없이 효율적으로 계산할 수 있음