### PR TITLE
20240706 yoonhye

### DIFF
--- a/yoonhye/PROGRAMMERS/[PGS] 석유 시추.py
+++ b/yoonhye/PROGRAMMERS/[PGS] 석유 시추.py
@@ -1,15 +1,14 @@
 from collections import deque
 
+
 def bfs(arr, i, j, num):
     d = [(0, 1), (0, -1), (1, 0), (-1, 0)]
     m, n = len(arr[0]), len(arr)  # 열, 행
     queue = deque([(i, j)])
+    arr[i][j] = num
     count = 0
     while (queue):
         x, y = queue.popleft()
-        if arr[x][y] > 1:
-            continue
-        arr[x][y] = num
         count += 1
         for dx, dy in d:
             nx, ny = x + dx, y + dy
@@ -17,6 +16,7 @@ def bfs(arr, i, j, num):
                 continue
             if arr[nx][ny] == 1:
                 queue.append((nx, ny))
+                arr[nx][ny] = num
 
     return count
 

--- a/yoonhye/PROGRAMMERS/[PGS] 석유 시추.py
+++ b/yoonhye/PROGRAMMERS/[PGS] 석유 시추.py
@@ -1,0 +1,43 @@
+from collections import deque
+
+def bfs(arr, i, j, num):
+    d = [(0, 1), (0, -1), (1, 0), (-1, 0)]
+    m, n = len(arr[0]), len(arr)  # 열, 행
+    queue = deque([(i, j)])
+    count = 0
+    while (queue):
+        x, y = queue.popleft()
+        if arr[x][y] > 1:
+            continue
+        arr[x][y] = num
+        count += 1
+        for dx, dy in d:
+            nx, ny = x + dx, y + dy
+            if nx < 0 or ny < 0 or nx >= n or ny >= m:
+                continue
+            if arr[nx][ny] == 1:
+                queue.append((nx, ny))
+
+    return count
+
+
+def solution(land):
+    answer = 0
+    m, n = len(land[0]), len(land)  # 열, 행
+    num = 2
+    oil = dict()
+    for i in range(n):
+        for j in range(m):
+            if land[i][j] == 1:
+                oil[num] = bfs(land, i, j, num)
+                num += 1
+
+    columns = [0 for _ in range(m)]
+    for i in range(m):
+        visited = set()
+        for j in range(n):
+            if land[j][i] > 1 and land[j][i] not in visited:
+                visited.add(land[j][i])
+                columns[i] += oil[land[j][i]]
+
+    return max(columns)


### PR DESCRIPTION
# [PGS] 석유 시추

**⏰ 0시간 45분  📌BFS**



## 풀이

- 2차원 배열 land를 순회하면서 1을 만날때마다 BFS를 수행한다.
    - BFS를 수행하면서 각 석유 덩어리에 2번부터 번호를 차례대로 붙여주고, 1대신에 해당 번호값을 넣어준다. 만약 덩어리가 3개라면 석유 덩어리는 번호 2, 3, 4가 존재할 것이다.
    - BFS를 수행하면서 덩어리의 크기도 함께 구해준다.
- 위의 과정이 끝난 이후에는 석유가 있는 위치에 해당 석유의 번호가 적혀있을 것이다. 또한 석유 번호에 따른 석유 덩어리의 크기 정보를 얻을 수 있다. 이 정보를 이용하여 1번 열부터 m번 열까지 순회하면서 각 열에서 얻을 수 있는 석유량을 구한다.

## 피드백

- 없음

## 코드
- bfs 함수 - 최악의 경우 전체 배열 탐색 : `O(n*m)`
- 처음 2중 for문 시간복잡도 : `O(n*m)` 
- 두 번째 2중 for문 시간복잡도 : `O(n*m)`
- max(columns) : `O(m)`

⇒ 최종 시간복잡도 : `O(m*n)`
1 ≤ m, n ≤ 500 이므로 제한 시간 안에 통과 가능.