### PR TITLE
seoyeon / 7월 2주차 목요일 / 3문제

### DIFF
--- a/seoyeon/프로그래머스/연습문제/연속 펄스 부분 수열의 합.py
+++ b/seoyeon/프로그래머스/연습문제/연속 펄스 부분 수열의 합.py
@@ -1,0 +1,61 @@
+#1. 20/100
+def solution(sequence):
+    answer = 0
+    
+    pulse1 = [-1 for _ in range(len(sequence))]
+    #누적
+    sum1 = [0 for _ in range(len(sequence))]
+    sum1_val = 0
+    for i in range(len(sequence)):
+    
+        if i%2==0:
+            pulse1[i] = sequence[i]
+        else:
+            pulse1[i] = sequence[i] * (-1)
+        sum1_val += pulse1[i]
+        sum1[i] = sum1_val
+                
+    pulse2 = [-1 for _ in range(len(sequence))]
+    sum2 = [0 for _ in range(len(sequence))]
+    sum2_val = 0
+    for i in range(len(sequence)):
+        pulse2[i] = pulse1[i] * (-1) 
+        sum2_val += pulse2[i]
+        sum2[i] = sum2_val
+
+    if max(sum1) > max(sum2):
+        max_idx = sum1.index(max(sum1))
+    else:
+        max_idx = sum2.index(max(sum2))
+    
+    answer_lst = [0 for _ in range(max_idx)]
+    
+    for i in range(max_idx):
+        for j in range(i,max_idx+1):
+            answer_lst[i] += pulse2[j]
+    answer = max(answer_lst)
+    
+    return answer
+
+#2. 100/100
+def solution(sequence):
+    answer = 0
+    
+    dp1 = [0 for _ in range(len(sequence))]
+    dp2 = [0 for _ in range(len(sequence))]
+    
+    dp1[0] = sequence[0]*(-1)
+    dp2[0] = sequence[0]
+    
+    pulse = 1
+    for k in range(1,len(sequence)):
+        pulse1 = sequence[k] * pulse
+        pulse2 = sequence[k] * pulse*(-1)
+    
+        dp1[k] = max(dp1[k-1]+pulse1, pulse1)
+        dp2[k] = max(dp2[k-1]+pulse2, pulse2)
+    
+        pulse *= (-1)
+
+    answer = max(max(dp1), max(dp2))
+    return answer

--- a/seoyeon/프로그래머스/연습문제/연속된 부분 수열의 합.py
+++ b/seoyeon/프로그래머스/연습문제/연속된 부분 수열의 합.py
@@ -1,0 +1,45 @@
+# 41.2/100
+def solution(sequence, k):
+    answer = []
+    dif_min = float("inf")
+    
+    for p in range(len(sequence)-1,-1,-1):
+        sum = sequence[p]
+        if sum == k:
+            answer = [p,p]
+            break
+            
+        for l in range(p-1,-1,-1):
+            sum += sequence[l]
+
+            if sum > k:
+                break
+            elif sum == k:
+                if p-l <= dif_min:
+                    dif_min = p-l
+                    answer = [l,p]
+                break
+    
+    
+    return answer
+
+#2. 100/100
+def solution(sequence, k):
+    answer = [-1,-1]
+    dict = {0:-1}   #key가 0~해당 index까지의 합, value가 index. 초기 dict[0]=-1은 첫 인덱스부터 시작하는 경우
+    
+    sum = 0
+    for i in range(len(sequence)):
+        sum += sequence[i]
+        dict[sum] = i
+        
+        if (sum-k) in dict:
+
+            if answer==[-1,-1]:
+                answer = [dict[sum-k]+1, i]
+                continue
+
+            if answer[1]-answer[0] != i-dict[sum-k]-1:
+                answer = [dict[sum-k]+1, i] #시작 인덱스, 종료 인덱스
+
+    return answer

--- a/seoyeon/프로그래머스/연습문제/표현 가능한 이진트리.py
+++ b/seoyeon/프로그래머스/연습문제/표현 가능한 이진트리.py
@@ -1,0 +1,43 @@
+import math
+
+def check(number_bin, prev_parent):#number_bin은 이진수 리스트 슬라이싱한 리스트, prev_parent는 이전 부모가 "1"인지 여부 
+    
+    mid = len(number_bin)//2
+    #number_bin이 비어 있지 않은 경우
+    if number_bin:
+        #bool 타입. 아래 자식이 "1"인 경우, son = True
+        son = (number_bin[mid]=="1")
+    #없으면 반환
+    else:
+        return 1
+    
+    #son이 있으면 그 위의 부모가 반드시 존재해야 함 
+    if son and not prev_parent:
+        return 0
+    else:
+        return check(number_bin[mid+1:],son) and check(number_bin[:mid],son)
+    
+    
+def sol(number):
+    if number == 1:
+        return 1
+    
+    number_bin = bin(number)[2:]
+    
+    #이진트리는 2^n - 1 형태
+    #math.log(x,2) = log_2(X)
+    digit = 2 ** (int(math.log(len(number_bin), 2)) + 1) - 1
+    number_bin = "0" * (digit - len(number_bin)) + number_bin
+
+    if number_bin[len(number_bin)//2]=="1" and check(number_bin, True):
+        return 1
+    else:
+        return 0
+    
+def solution(numbers):
+    answer = []
+    
+    for number in numbers:
+        answer.append(sol(number))
+        
+    return answer


### PR DESCRIPTION
## [PSG] 연속된 부분 수열의 합
#### ⏰ 1시간 24분 📌 누적합
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/178870>

### 문제 해결

> 시간 복잡도 **O(n)**
> 

1. key가 0~index까지의 합, value가 index인 dictionary **dict** 생성
    1. 즉, dict[15] = 1은 sequence[0]+sequence[1] = 15라는 뜻
    2. 초기 dict = {0:-1}은 첫 인덱스부터 시작하는 경우를 위해 정의
2. for i in range(len(sequence)) 
    1. sum += sequence[i]
        - sum은 0번째 인덱스부터 i번째 인덱스까지의 총합
    2. dict[sum]=i
        - dictionary에 저장
    3. if (sum-k) in dict
        - sum-k가 dict에 존재하는 경우, 해당 인덱스+1부터 현재 인덱스 i까지의 합이 k가 됨
    4. if answer==[-1,-1]
        - 처음으로 k가 되는 경우
    5. 길이가 더 짧은 경우에만 answer가 될 수 있음
        - 길이가 같은 경우는 answer가 될 수 없음
        - dict의 key는 누적 값이므로 뒤로 갈 수록(i가 커질수록) sum이 커져 answer의 인덱스 길이가 짧아질 수밖에 없으므로 `answer[1]-answer[0] > i-dict[sum-k]-1` 이 아닌 `answer[1]-answer[0] != i-dict[sum-k]-1` 사용

### 피드백

- 처음에 이중 for문으로 코드를 만들었는데, 많은 테스트 케이스에서 시간 초과 발생 ⇒ n이 커 O(n^2) 사용 불가능
- 시간 제한이 있는 경우 dictionary 사용하면 시간 복잡도가 작아지고 문제에서는 index와 값이 모두 필요하기 때문에 dictionary 활용하는 방법 고안

## [PSG] 표현 가능한 이진트리
#### ⏰ 2시간 00분 📌 DFS
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/150367>

### 문제 해결

1. numbers 리스트의 원소 number를 하나씩 탐색
2. sol 함수
    1. number==1인 경우, 노드를 하나만 가지므로 이진트리
    2. 십진수를 원하는 이진수로 변경
        1. `bin(number)` 의 결과가 0b로 시작하므로 앞의 두 자리 제거해 `bin(number)[2:]`
        2. 포화 이진 트리의 노드 개수는 2**n - 1이고, n은 `int(math.log(len(number_bin),2))+1)`
        3. 기존의 number_bin 개수에서 모자란 만큼 앞에 추가
    3. number_bin의 가운데 인덱스의 값이 1이고 check 함수 반환값이 1인 경우, return 1 ⇒ 이진트리 가능
        1. 그렇지 않은 경우, return 0 ⇒ 이진 트리 불가능
3. check 함수
    1. 매개변수로 (1) 이진수 리스트와 (2) 부모가 존재하는지(= “1”인지) 여부 
    2. 매개변수의 이진수 리스트의 가운데 인덱스 값 mid 변수 
    3. number_lst가 빈 리스트가 아닌 경우 number_lst의 가운데 인덱스(노드)가 존재하는지 확인, 빈 리스트의 경우 return 1
        1. number_bin[mid]==”1”인 경우 존재
    4. son이 존재하면 반드시 그 위의 부모(prev_parent) 노드가 존재해야 함
    5. 존재하는 경우, number_bin 리스트를 두 개로 나누어 다시 check, 존재하지 않는 경우, return 0

### 피드백

- 이진트리에 대해 정확히 알지 못 해 스스로 해결하지 못 함

## [PSG] 연속 펄스 부분 수열의 합
#### ⏰ 1시간 40분 📌 DP
### 문제
<https://school.programmers.co.kr/learn/courses/30/lessons/161988>

### 문제 해결

1. dp1과 dp2 정의
    1. dp1과 dp2는 각각 현재 인덱스에서의 최댓값을 저장하는 리스트
2. dp1[0]과 dp2[0]을 각각 정의
    1. 아래 for문에서는 dp1[k-1], dp2[k-1]을 사용하기에 처음 값은 정의해야함
    2. for문의 pulse와 맞게 dp1[0]에 -1 을 곱해줌
3. for문
    1. -1 또는 1을 곱해 pulse 정의
    2. (1) 직전의 값에 pulse를 더한 값과 (2) 현재의 pulse 값 하나 중 최댓값을 선택해 dp에 저장
    3. pulse는 계속해서 바뀌어야 하므로 `pulse *= (-1)`
4. dp1과 dp2 각각에서의 최댓값을 구하고, 두 최댓값 중 최댓값이 정답

### 피드백

- 누적합을 이용해 최선의 범위를 구하려고 했음
    - 범위 말고 값만 필요한 경우에는 DP 사용 !
- 값을 모두 저장한 후 계산하려 했는데 입력 값이 너무 커 시간 초과 발생
    - 생각 나는대로 구현하는 습관 버리고 고민한 후에 코드 짜기 ㅠㅠ