### PR TITLE
yoonhye / 7월 3주차 화요일 / 1문제

### DIFF
--- a/yoonhye/SAMSUNG/마법_숲_탐색/Main.java
+++ b/yoonhye/SAMSUNG/마법_숲_탐색/Main.java
@@ -1,0 +1,136 @@
+package SAMSUNG.마법_숲_탐색;
+
+import java.util.*;
+import java.io.*;
+
+class Position{
+    int x;
+    int y;
+    int d;
+    Position(int x, int y, int d){
+        this.x = x;
+        this.y = y;
+        this.d = d;
+    }
+}
+public class Main {
+    public static boolean move(int[][] board, int x, int y, int[][] delta){
+
+        int R = board.length;
+        int C = board[0].length;
+        for (int[] d : delta){
+            int nx = x+d[0], ny = y+d[1];
+            if (nx<0 || ny<0 || nx>=R || ny>=C || board[nx][ny] > 0){
+                return false;
+            }
+        }
+        return true;
+    }
+    public static int move_g(int[][] board, int n, int K, HashMap<Integer, Position> info){
+        int[][] direction = {{-1,0}, {0,1}, {1,0}, {0,-1}};
+        int[] visited = new int[K+1];
+        int R = board.length;
+        int C = board[0].length;
+
+        Deque<Integer> queue = new ArrayDeque<>();
+        queue.add(n);
+
+        int max_x = 0;
+        while(!queue.isEmpty()){
+            int num = queue.poll();
+            Position p = info.get(num);
+            int x = p.x, y = p.y, d = p.d;
+            int ex = direction[d][0] + x, ey = direction[d][1]+ y;
+
+            max_x = Math.max(max_x, x);
+
+            for(int[] dir : direction){
+                int nx = dir[0] + ex, ny = dir[1] + ey;
+                if (nx < 0 || ny < 0 || nx >= R || ny >= C){
+                    continue;
+                }
+                int new_n = board[nx][ny];
+                if (new_n != 0 && visited[new_n] == 0){
+                    queue.add(new_n);
+                    visited[new_n] = 1;
+                }
+            }
+        }
+        return max_x;
+
+    }
+
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+
+        int R = Integer.parseInt(st.nextToken());
+        int C = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        int[][] board = new int[R+3][C];
+
+        int[][] info = new int[K][2];   //info[i][0] : 출발 열, info[i][1] : 출구 방향 정보
+        for (int i = 0; i < K; i++){
+            st = new StringTokenizer(br.readLine());
+            info[i][0] = Integer.parseInt(st.nextToken())-1;
+            info[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        int answer = 0;
+        int[][] delta_down = {{2,0}, {1,1}, {1,-1}};
+        int[][] delta_left = {{0,-2}, {-1,-1}, {1,-1}};
+        int[][] delta_right = {{0, 2}, {1,1}, {-1,1}};
+        int[][] direction = {{-1,0}, {0,1}, {1,0}, {0,-1}};
+        HashMap<Integer, Position> g_info = new HashMap<Integer, Position>();
+
+        for(int i = 0; i < K; i++){
+            int y = info[i][0];
+            int x = 1;
+            int d = info[i][1];
+            while(true){
+
+                if(move(board, x, y, delta_down)){
+                    x++;
+                }else{
+                    //왼 -> 아래 (출구 반시계방향 이동)
+                    if(move(board, x, y, delta_left) && move(board, x, y-1, delta_down)){
+                        x++;
+                        y--;
+                        if (d==0) d = 3;
+                        else d--;
+                    }else{
+                        //오 -> 아래 (출구 시계방향 이동)
+                        if(move(board, x, y, delta_right) && move(board, x, y+1, delta_down)){
+                            x++;
+                            y++;
+                            if (d==3) d = 0;
+                            else d++;
+                        }else{
+                            break;
+                        }
+                    }
+                }
+            }
+            if (x<=3){  //board reset
+                board = new int[R+3][C];
+                continue;
+            }
+            //골렘 최종 위치를 board에 남기고 골렘 번호에 따른 출구 정보 저장
+            g_info.put(i+1, new Position(x, y, d));
+
+            board[x][y] = i+1;
+            for(int[] dir : direction){
+                board[x+dir[0]][y+dir[1]] = i+1;
+            }
+
+            //정령 이동
+            int res = move_g(board, i+1, K, g_info)-1;
+            answer += res;
+
+        }
+        System.out.println(answer);
+
+    }
+}


### PR DESCRIPTION
## [ETC] 마법의 숲 탐색
⏰ 1시간 50분 📌BFS/DFS

## 풀이
- 이 문제는 골렘의 이동과 정령의 이동을 처리하면 되는 문제이다. 골렘이 숲을 벗어난 상태에서 출발하고, 이동 후에도 몸의 일부가 숲을 벗어난 상태이면 숲을 초기화시켜야 한다. 그러므로 골렘의 길이(3)만큼 행을 늘려서 보드판을 (R+3)XC 형태로 구성하였다. 이렇게 하면 골렘이 항상 1행 c열에서 출발하도록 할 수 있다. 골렘이 이동을 끝냈을 때 행의 위치가 3이하인 경우, 골렘이 이동을 실패했으므로 보드판을 리셋한다.
- **`골렘의 이동`**
    - 아래로 이동할 수 있는지 확인 → 안되면 왼쪽, 아래로 이동할 수 있는지 확인 → 안되면 오른쪽, 아래로 이동할 수 있는지 확인
    - 위와 같은 절차를 밟아야하기 때문에 `move_down()`의 조건을 만족하지 못하면 `move_left()`를 실행하고, `move_left()`의 조건을 만족하지 못하면 `move_right()`를 실행하도록 하였다. `move_right()`의 조건도 만족하지 못하면 `False`를 반환하게 하였다.
    - 골렘이 성공적으로 이동했으면 골렘이 차지하고 있는 모든 칸에 번호값을 넣어준다. (정령의 이동을 처리할 때 어느 부분에 몇 번 골렘이 위치하고 있는지 확인하기 위함)
    - 그리고 따로 골렘의 정보를 저장해준다. 골렘의 정보를 저장하는 형태는 골렘의 번호를 Key로 하고 골렘의 가운데 좌표(x,y)와 출구의 방향을 Value로 하는 딕셔너리 형태이다.
- **`정령의 이동`**
    - 골렘이 완전히 이동한 후 정령을 이동시킨다.
    - BFS, DFS 둘 다 가능하다. (python에서는 DFS로 했고, java에서는 BFS로 했다)
    - 출구의 위치를 기준으로 상하좌우에 다른 골렘의 번호가 존재하면(0보다 큰 숫자) 해당 번호를 queue 혹은 stack에 넣어주고 방문 처리를 해준다.
    - 정령이 이동 가능한 골렘으로 모두 이동하면서 행 번호의 최댓값을 구한다.

## 피드백

- 자바에 아직 익숙하지 않아서 자바로 구현하려니까 문법을 찾아보느라 시간이 오래 걸렸다.

## 코드

📌 골렘이 이동하는 과정 : 골렘은 최대 R-1행까지 이동 가능하므로 `O(R)`
정령이 이동하는 과정(BFS/DFS) : `O(RC)`
위 과정이 총 K번 진행되므로 최종 시간복잡도는 `O(KRC)`

- 5≤*R*,*C*≤70
- 1≤*K*≤1000

이므로 제한 시간 안에 통과 가능