### PR TITLE
[BOJ] 6987 월드컵

### DIFF
--- a/seoyeon/백준/SAFFY_Rec/6987.py
+++ b/seoyeon/백준/SAFFY_Rec/6987.py
@@ -1,0 +1,34 @@
+from itertools import combinations
+
+def back_tracking(round):
+    global answer
+    #모든 라운드가 끝났을 때 승,무,패 횟수 모두 0이면 answer=1
+    if round==15:
+        answer=1
+        #승,무,패 중 하나라도 0이 아니면 answer=0
+        for i in res:
+            if i.count(0)!=3:
+                answer=0
+                break
+        return
+    #t1,t2는 팀 의미
+    t1,t2=game[round]
+    
+    #x,y는 승,무,패를 결정하는 인덱스
+    for x,y in ((0,2),(1,1),(2,0)):
+        if res[t1][x]>0 and res[t2][y]>0:
+            res[t1][x]-=1 #t1
+            res[t2][y]-=1 #t2
+            back_tracking(round+1)
+            res[t1][x]+=1 #다시복구
+            res[t2][y]+=1
+
+result=[]
+game=list(combinations(range(6),2)) #경기 조합 game=[(0,1),(0,2),...]
+for _ in range(4):
+    temp=list(map(int,input().split()))
+    res=[temp[i:i+3] for i in range(0,16,3)] #res=[[5,0,0],[0,5,0],...]. 팀0은 5승0무0패,팀1은0승5무0패
+    answer=0
+    back_tracking(0)
+    result.append(answer)
+print(*result)


### PR DESCRIPTION
## [BOJ] 월드컵
#### ⏰ 01:40  📌 DFS
### 문제
<https://www.acmicpc.net/problem/6987>

### 문제 해결

> 시간복잡도 O(3^15)
> 

combinations를 통해 두 팀씩 짝지음
두 팀에서 나올 수 있는 결과 경우는 (0,2),(1,1),(2,0) 
-  (0,2)는 t1이 승리,t2가 패배한 경우, (1,1)은 무승부, (2,0)은 t2가 승리,t1이 패배한 경우

입력받은 팀의 결과에서 해당 결과에 해당하는 인덱스 1 빼기

모든 라운드가 진행되었을 때 승,무,패 횟수 모두 0이면 answer=1 (가능한 결과)
- res 중 하나라도 0이 아니면 answer=0 (불가능한 결과)

```
    #모든 라운드가 끝났을 때 승,무,패 횟수 모두 0이면 answer=1
    if round==15:
        answer=1
        #승,무,패 중 하나라도 0이 아니면 answer=0
        for i in res:
            if i.count(0)!=3:
                answer=0
                break
        return
```

### 피드백

단순히 win,lose를 비교하고 draw를 처리하려 했는데 실패
모든 경우의 수를 찾아 비교해야 하는 문제
리스트를 인덱스로 잘라 저장하는 코드가 어색 -> 자주 사용해볼 것