### PR TITLE
seoyeon / 1월 5주차 목요일 / 1문제

### DIFF
--- a/seoyeon/백준/SAFFY_Rec/1987.py
+++ b/seoyeon/백준/SAFFY_Rec/1987.py
@@ -1,38 +1,39 @@
 #백준 #1987 알파벳
 
-def dfs(x,y,alpha,cnt):
-    global ans
+def dfs(x, y):
+    global board, R, C
 
-    if cnt>ans:
-        ans = cnt
+    movement_array = [[-1,0],[1,0],[0,-1],[0,1]]
 
-    d_lst = [[0,-1],[0,1],[1,0],[-1,0]]
+    max_depth = 0
+    queue = set() # 중복 방지. 동일한 위치 오지 않도록 함
+    queue.add((x, y, board[x][y]))
+    while queue: 
+        current_x, current_y, current_visited = queue.pop() #current_visited는 문자열
+        
+        max_depth = max(max_depth, len(current_visited))
+        if max_depth == 26: #알파벳 개수
+            return 26
+        for movement in movement_array:
+            next_x = current_x + movement[0]
+            next_y = current_y + movement[1]
+            if 0 <= next_x < R and 0 <= next_y < C and board[next_x][next_y] not in current_visited:
+                queue.add((next_x, next_y, current_visited + board[next_x][next_y]))
+    return max_depth       
 
-    for dx,dy in d_lst:
-        nx = x+dx
-        ny = y+dy
-        if 0<=nx<R and 0<=ny<C and visited[nx][ny]==False and boards[nx][ny] not in alpha:
-            visited[nx][ny]=True
-            alpha[boards[nx][ny]]=0
-            dfs(nx,ny,alpha,cnt+1)
-            visited[nx][ny]=False
-            del alpha[boards[nx][ny]]
-            
 
 
 R, C = map(int,input().split())
-boards = ["" for _ in range(R)]
+board = ["" for _ in range(R)]
 
 for r in range(R):
-    lst = input()
-    boards[r] = lst
+    lst=input()
+    board[r]=lst
 
-ans = 0
 visited=[[False for _ in range(C)] for _ in range(R)]
 
 visited[0][0]=True
-dict = {}
-dict[boards[0][0]]=0
-dfs(0,0,dict,1)
 
-print(ans)
+print(dfs(0,0))
+
+#print(max_depth)

--- a/seoyeon/백준/SAFFY_Rec/1987.py
+++ b/seoyeon/백준/SAFFY_Rec/1987.py
@@ -1,0 +1,38 @@
+#백준 #1987 알파벳
+
+def dfs(x,y,alpha,cnt):
+    global ans
+
+    if cnt>ans:
+        ans = cnt
+
+    d_lst = [[0,-1],[0,1],[1,0],[-1,0]]
+
+    for dx,dy in d_lst:
+        nx = x+dx
+        ny = y+dy
+        if 0<=nx<R and 0<=ny<C and visited[nx][ny]==False and boards[nx][ny] not in alpha:
+            visited[nx][ny]=True
+            alpha[boards[nx][ny]]=0
+            dfs(nx,ny,alpha,cnt+1)
+            visited[nx][ny]=False
+            del alpha[boards[nx][ny]]
+            
+
+
+R, C = map(int,input().split())
+boards = ["" for _ in range(R)]
+
+for r in range(R):
+    lst = input()
+    boards[r] = lst
+
+ans = 0
+visited=[[False for _ in range(C)] for _ in range(R)]
+
+visited[0][0]=True
+dict = {}
+dict[boards[0][0]]=0
+dfs(0,0,dict,1)
+
+print(ans)


### PR DESCRIPTION
## [BOJ] 1987 알파벳
#### ⏰ 01:20  📌 BFS, Backtracking
### 문제
<https://www.acmicpc.net/problem/1987>

### 문제 해결

> 시간복잡도 O(R*C)
> 

queue를 set()으로 설정해 중복 처리 방지
- visited를 사용하지 않고도 해결 가능
방문한 알파벳을 문자열로 처리해 체크

### 피드백

- DFS로 문제풀 때에는 시간 초과 오류 발생
  - 시간 초과 오류 해결하려 했는데 DFS로는 해결할 수 없음 => pypy로 제출할 때 아슬아슬하게 되어 시간 초과를 완벽히 처리했다고 볼 수 없음
  - BFS로 시간 초과 해결
- 한 번 씩만 방문해야 하기 때문에 queue를 set()으로 설정
  - visited 사용해도 되는데, set()으로 설정해 시간 줄임
- current_visited를 원래 dictionary를 사용해 해결했는데 단순히 문자열로도 처리 가능
  - 문자열로도 되는지 몰랐음 