### PR TITLE
seoyeon / 2월 1주차 화요일 / 1문제

### DIFF
--- a/seoyeon/백준/SAFFY_Rec/2931.py
+++ b/seoyeon/백준/SAFFY_Rec/2931.py
@@ -1,0 +1,144 @@
+#백준 2931 가스관
+from collections import deque
+
+def solv(prev_x,prev_y,x,y,p):
+    lst = []
+    if p==pipe[0]:
+        if prev_x>x:
+            lst.append([x-1,y]) #위로
+        else:
+            lst.append([x+1,y]) #아래로
+    elif p==pipe[1]:
+        if prev_y>y:
+            lst.append([x,y-1]) #왼쪽
+        else:
+            lst.append([x,y+1]) #오른쪽
+    elif p==pipe[2]:
+        if prev_x>x and prev_y==y: #아래->위로 들어옴
+            lst.append([x,y-1])
+            lst.append([x,y+1])
+            lst.append([x-1,y])
+        elif prev_x<x and prev_y==y: #위->아래로 들어옴
+            lst.append([x,y-1])
+            lst.append([x,y+1])
+            lst.append([x+1,y])
+        elif prev_x==x and prev_y>y: #오른쪽->왼쪽으로 들어옴
+            lst.append([x,y-1])
+            lst.append([x+1,y])
+            lst.append([x-1,y])
+        elif prev_x==x and prev_y<y: #왼쪽->오른쪽으로 들어옴
+            lst.append([x-1,y])
+            lst.append([x+1,y])
+            lst.append([x,y+1])
+        
+
+    elif p==pipe[3]:
+        if prev_y>y: #왼쪽->오른쪽
+            lst.append([x+1,y])
+        else:
+            lst.append([x,y+1])
+
+    elif p==pipe[4]:
+        if prev_x<x: #위->아래
+            lst.append([x,y+1])
+        else:
+            lst.append([x-1,y])
+    elif p==pipe[5]:
+        if prev_y<y: #왼쪽->오른쪽
+            lst.append([x-1,y])
+        else:
+            lst.append([x,y-1])
+
+    elif p==pipe[6]:
+        if prev_x>x: #위->아래
+            lst.append([x,y-1])
+        else:
+            lst.append([x+1,y])
+
+    return lst
+
+def bfs(i,j):
+    global board,ans
+
+    d_lst = [[-1,0],[1,0],[0,-1],[0,1]]
+    Q = deque()
+
+    for dx,dy in d_lst:
+        nx = i+dx
+        ny = j+dy
+        if 0<=nx<R and 0<=ny<C and board[nx][ny]!="." and visited[nx][ny]==False:
+            visited[nx][ny]=True
+            Q.append([i,j,nx,ny,board[nx][ny]])
+
+    
+    while Q:
+        prev_x,prev_y,x,y,p = Q.popleft()
+
+        lsts = solv(prev_x,prev_y,x,y,p)
+        for lst in lsts:
+            nx,ny = lst[0],lst[1]
+            if 0<=nx<R and 0<=ny<C:
+                if board[nx][ny] in pipe and visited[nx][ny]==False:
+                    visited[nx][ny]=True
+                    Q.append([x,y,nx,ny,board[nx][ny]])
+                if board[nx][ny] == ".":
+                    ans = [nx,ny]
+
+
+R, C = map(int,input().split())
+board = [list(input()) for _ in range(R)]
+pipe = ["|","-","+","1","2","3","4"]
+visited = [[False for _ in range(C)] for _ in range(R)]
+
+ans = [-1,-1]
+start = [-1,-1]
+end = [-1,-1]
+for i in range(R):
+    for j in range(C):
+        if board[i][j]=="M":
+            start[0],start[1] = i,j
+        elif board[i][j]=="Z":
+            end[0],end[1] = i,j
+
+bfs(start[0],start[1])
+bfs(end[0],end[1])
+
+d_lst = [[-1,0],[1,0],[0,-1],[0,1]]
+
+x,y = ans[0],ans[1]
+ans_d = [False,False,False,False] #상하좌우
+for dx,dy in d_lst:
+    nx = x+dx
+    ny = y+dy
+    if 0<=nx<R and 0<=ny<C:
+        #상하좌우 순서
+        if nx<x and ny==y:
+            if board[nx][ny]=="|" or board[nx][ny]=="+" or board[nx][ny]=="1" or board[nx][ny]=="4":
+                ans_d[0]=True
+        elif nx>x and ny==y:
+            if board[nx][ny]=="|" or board[nx][ny]=="+" or board[nx][ny]=="2" or board[nx][ny]=="3":
+                ans_d[1]=True
+        elif nx==x and ny<y:
+            if board[nx][ny]=="-" or board[nx][ny]=="+" or board[nx][ny]=="1" or board[nx][ny]=="2":
+                ans_d[2]=True
+        elif nx==x and ny>y:
+             if board[nx][ny]=="-" or board[nx][ny]=="+" or board[nx][ny]=="3" or board[nx][ny]=="4":
+                ans_d[3]=True           
+
+ans_p = ""
+if ans_d[0]==ans_d[1]==ans_d[2]==ans_d[3]==True:
+    ans_p="+"
+elif ans_d[0]==ans_d[1]==True:
+    ans_p="|"
+elif ans_d[2]==ans_d[3]==True:
+    ans_p="-"
+elif ans_d[1]==ans_d[3]==True:
+    ans_p="1"
+elif ans_d[0]==ans_d[3]==True:
+    ans_p="2"
+elif ans_d[2]==ans_d[0]==True:
+    ans_p="3"
+elif ans_d[1]==ans_d[2]==True:
+    ans_p="4"
+
+print(ans[0]+1,ans[1]+1,ans_p)


### PR DESCRIPTION
## [BOJ] 2931 가스관
#### ⏰ 01:30  📌 BFS, 구현
### 문제
<https://www.acmicpc.net/problem/2931>

### 문제 해결

> 시간복잡도 O(R*C)
> 

1. solv(prev_x,prev_y,x,y,p)

| prev_x와 x를 비교하고 prev_y와 y를 비교한 결과를 p와 연관지어, 다음 bfs 함수에서 확인해야 하는 좌표를 lst에 넣어 반환

2. bfs(x,y)

| 결과적으로 지워진 블럭의 좌표인 ans를 찾는 것이 목표 

- 해당 좌표 x,y로부터 시작했을 때 가장 처음엔 상하좌우 탐색
- 상하좌우 중 board[nx][ny]!="."인 경우 Q에 삽입
- Q에서 좌표를 하나씩 빼서 solv() 함수를 통해 다음에 확인할 좌표 찾음
  - 다음에 확인할 좌표의 board 값이 "."이 아니고 visited가 False인 경우, visited를 True로 한 후 Q에 넣고 다시 진행  
  - 다음에 확인할 좌표의 board 값이 "."인 경우, ans 반환

3. ans 좌표 주위(상하좌우) 좌표의 board 값 확인해 적절히 ans_d 값 업데이트
- ans_d는 각각 ans의 상하좌우 의미
- 예를 들어, ans_d = [True,True,False,False]인 경우 ans의 위, 아래에 board값이 "."이 아닌 값 존재

4. ans_d에 따라 ans_p 결정
- 예를 들어, ans_d=[True,True,False,False]인 경우 ans의 위와 아래의 board 값이 "."이 아니므로 ans_p는 위아래를 연결하는 "|"

visited 사용하지 않는 경우 while Q 내에서 무한반복 -> BFS 사용 시 반드시 visited로 체크할 것

### 피드백

모든 케이스를 생각해내 구현으로 해결했는데, 비슷한 로직이 반복되어 더 간단하게 푸는 방법이 있을 것 같음 