### PR TITLE
seoyeon / 2월 3주차 화요일 / 1문제

### DIFF
--- a/seoyeon/백준/SAFFY_Rec/1922_1.py
+++ b/seoyeon/백준/SAFFY_Rec/1922_1.py
@@ -1,0 +1,39 @@
+#백준 #1922 네트워크 연결
+#Prim's Algorithm
+import heapq
+
+def prim(idx):
+    visited = [False for _ in range(N)]
+    weight = [float("inf") for _ in range(N)]
+
+    #시작노드
+    weight[idx]=0
+    
+    #heapq
+    edges_heap = [[0,idx]] # [가중치,노드]
+    heapq.heapify(edges_heap)
+
+    while edges_heap:
+        w,node = heapq.heappop(edges_heap)
+        
+        if visited[node]==False:
+            visited[node]=True
+            #갈 수 있는 노드 찾아서 heapq에 삽입
+            for next_w,next_node in edges[node]:
+                #방문한 적 없고 최솟값인 경우
+                if visited[next_node]==False and weight[next_node] > next_w:
+                    weight[next_node] = next_w
+                    heapq.heappush(edges_heap, [next_w,next_node])
+    print(sum(weight))
+
+
+N = int(input())
+M = int(input())
+edges = [[] for _ in range(N)]
+
+for m in range(M):
+    a,b,c = map(int,input().split())
+    edges[a-1].append([c,b-1])
+    edges[b-1].append([c,a-1])
+
+prim(0)


### PR DESCRIPTION
## [BOJ] 1922 네트워크 연결
#### ⏰ 01:00  📌 MST, Prim's Algorithm   📈 X
### 문제
<https://www.acmicpc.net/problem/1922>

### 문제 해결

> 시간복잡도 O(E*log V). E:간선 개수, V:정점 개수
> 

1. 간선들 edges에 추가
2. prim(idx)
  a. visited와 weight 초기화
    - visited로 방문 처리
    - weight는 해당 노드에 접근할 수 있는 가장 작은 가중치
  b. 시작 노드 가중치 0으로 초기화
    - weight[idx] = 0
    - 처음 접하는 노드는 가중치를 가지지 않음
  c. edges_heap 
    - [가중치,노드]로 heap 생성
  d. while edges_heap
    - `heapq.heappop(edges_heap)`으로 edges_heap 하나씩 가져옴
    - 방문한 적 없는 경우, 방문 처리 후 처리
      - 방문할 수 있는 edges 중 방문한 적 없고 최소값을 weight에 업데이트 & edges_heap에 삽입 

### 피드백

동일한 MST 문제를 Kruskal과 Prim 알고리즘 사용해 각각 풀이
`weight[next_node] > next_w`가 이해가 잘 안 되었음 -> 더 작은 가중치로 next_node에 접근할 수 있는 경우 해당 방식으로 접근