### PR TITLE
seoyeon / 2월 3주차 수요일 / 1문제

### DIFF
--- a/seoyeon/SWExpertAcademy/3124/3124_1.py
+++ b/seoyeon/SWExpertAcademy/3124/3124_1.py
@@ -1,0 +1,41 @@
+#SWExpertAcademy #3124 최소 스패닝 트리
+#Prim's Algorithm
+import heapq
+
+def prim(n):
+    
+    visited=[False for _ in range(V)] 
+    weights=[float("inf") for _ in range(V)] #weight[0] 노드 0으로 갈 수 있는 최소 가중치 값
+
+    weights[n]=0
+    heap_edge = [[0,n]] #[가중치,노드]
+    heapq.heapify(heap_edge)
+
+    while heap_edge:
+        weight,node = heapq.heappop(heap_edge)
+        
+        if visited[node]==False:
+            visited[node]=True
+
+            for edge in edges[node]:
+                next_w, next_n = edge
+                if visited[next_n]==False and next_w<weights[next_n]:
+                    weights[next_n]=next_w
+                    heapq.heappush(heap_edge,[next_w,next_n])
+
+    return sum(weights)
+
+T = int(input())
+
+for t in range(1,T+1):
+    V,E = map(int,input().split())
+    edges = [[] for _ in range(V)]
+
+    for e in range(E):
+        a,b,c = map(int,input().split())
+        edges[a-1].append([c,b-1])
+        edges[b-1].append([c,a-1])
+
+    ans = prim(0)
+    print("#",t,sep="",end=" ")
+    print(ans)

--- a/seoyeon/백준/SAFFY_Rec/1753.py
+++ b/seoyeon/백준/SAFFY_Rec/1753.py
@@ -1,0 +1,45 @@
+#백준 #1753 최단경로
+#MST - Kruskal's Algorithm
+
+import heapq
+import sys
+input = sys.stdin.readline
+
+def solv(start_idx):
+    global dp
+    
+    #DP 정의
+    dp[start_idx]=0
+    Q=[[0,start_idx]] #[가중치,지나는인덱스]
+    heapq.heapify(Q)
+    
+    while Q:
+        n,idx = heapq.heappop(Q)
+
+        #현재 값이 더 크면 진행하지 않음
+        if dp[idx] < n:
+            continue
+
+        for w,next_n in edges[idx]:
+            next_w = n+w
+            if next_w < dp[next_n]:
+                dp[next_n] = next_w
+                heapq.heappush(Q,[next_w,next_n])
+    
+
+V,E = map(int,input().split()) #V: 정점의 수,E:간선의 수
+K = int(input()) #K:시작정점번호
+edges = [[] for _ in range(V)] #[가중치,정점]
+dp=[float("inf") for _ in range(V)]
+
+for e in range(E):
+    u,v,w = map(int,input().split()) #u,v:정점,w:가중치
+    edges[u-1].append([w,v-1])
+
+solv(K-1)
+
+for i in range(V):
+    if dp[i]==float("inf"):
+        print("INF")
+    else:
+        print(dp[i])

--- a/seoyeon/백준/SAFFY_Rec/1753.py
+++ b/seoyeon/백준/SAFFY_Rec/1753.py
@@ -1,5 +1,5 @@
 #백준 #1753 최단경로
-#MST - Kruskal's Algorithm
+#DP
 
 import heapq
 import sys


### PR DESCRIPTION
## [SWEA] 3124 최소 스패닝 트리
#### ⏰ 00:30  📌 MST 📈 X
### 문제
<https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV_mSnmKUckDFAWb>

### 문제 해결

> 시간복잡도 O(E log V)
> 

1. edge들 추가
2. visited, weights 정의
3. heap_edge 정의
- [가중치,노드]
4. while heap_edge
- heapq.heappop(heap_edge)로 heap_edge에서 값 하나씩 빼기
- 뺀 값이 방문한 적 없는 경우 계속 처리
  - visited[node]=True
  - 해당 노드와 연결된 모든 노드 중 방문한적없고 weights보다 작은 경우 weights 업데이트 & heapq에 값 추가 

### 피드백

왜 Kruskal로는 풀리는데 Prim's로 풀리지 않는지 모르겠다 ,, 풀려야하는거 아닌가 ㅠㅠ 


## [BOJ] 1753 최단 경로
#### ⏰ 01:10  📌 다익스트라 📈 X
### 문제
<https://www.acmicpc.net/problem/1753>

### 문제 해결

> 시간복잡도 O(E log V)
> 

1. edges 추가
- dp[i]는 start에서 i까지 갈 수 있는 최단 거리
2. solv(start)
- 시작 정점 초기화
  - dp[start_idx]=0 
- heapq
  - heapq에 데이터 삽입 
  -  while Q
    - `heapq.heappop(Q)`로 데이터 (n,idx) 빼기
    - 뺀 값(n) 이 dp[idx]보다 더 크면 아래 코드 진행하지 않음
    - 그렇지 않은 경우 뺀  edges[idx] 모두 처리 => w,next_n
      -  다음 가중치는 현재 가중치(n)+다음가중치(w)
      - 만약 next_w가 dp[next_n]보다 작은 경우 dp 업데이트 후 heapq에 데이터 삽입
     
3. dp 출력

### 피드백

MST와 BFS로 푸려했는데, MST는 특정 노드에서 시작할 수 없고, BFS로 풀기에는 각 간선의 가중치가 달라 해결하지 못함
최단 경로를 찾기 위해 DP 사용
