### PR TITLE
seoyeon / 3월 1주차 월요일 / 1문제

### DIFF
--- a/seoyeon/백준/DP/2579.py
+++ b/seoyeon/백준/DP/2579.py
@@ -1,0 +1,19 @@
+#백준 #2579 계단 오르기
+#DP
+
+N = int(input())
+steps = [0 for _ in range(301)]
+
+for n in range(N):
+    steps[n] = int(input())
+
+dp = [0 for _ in range(301)] #계단의 개수는 300 이하.dp[i]는 i까지의 점수의 최댓값
+
+dp[0]=steps[0]
+dp[1]=steps[0]+steps[1]
+dp[2]=max(steps[0]+steps[2],steps[1]+steps[2]) #
+
+for i in range(3,N):
+    dp[i]=max(dp[i-3]+steps[i-1]+steps[i], dp[i-2]+steps[i])
+
+print(dp[N-1])


### PR DESCRIPTION
## [BOJ] 2579 계단오르기
#### ⏰ 01:00  📌 DP 📈 X
### 문제
<https://www.acmicpc.net/problem/2579>

### 문제 해결

> 시간복잡도 O(N)
> 

i번째 계단은 i-1번째 계단에서 오거나 i-2번째 계단에서 접근 가능
i-1번째 계단에서 접근
- "i-3번째 + i-1번째 + i번째"로 진행해야 동시에 3개의 계단에 접근하지 않음
i-2번째 계단에서 접근
- "i-2번째 + i번째"로 진행해야 동시에 3개의 계단에 접근하지 않음

### 피드백

DP 어렵다 점화식을 못 생각해내겠음 