### PR TITLE
seoyeon / 3월 1주차 화요일 / 1문제

### DIFF
--- a/seoyeon/백준/DP/9461.py
+++ b/seoyeon/백준/DP/9461.py
@@ -1,0 +1,24 @@
+#백준 #9461 파도반 수열
+#DP
+
+def solv(N):
+    dp = [0 for _ in range(101)]
+    
+    dp[1],dp[2],dp[3] = 1,1,1
+    dp[4]=dp[3]+dp[1]
+    dp[5]=dp[4]
+    dp[6]=dp[5]+dp[3]
+    dp[7]=dp[6]+dp[2]
+    dp[8]=dp[7]+dp[1]
+
+    #처음 정의: 4~8까지
+    for i in range(9,101):
+        dp[i]=dp[i-1]+dp[i-5]
+    return dp[N]
+
+T = int(input())
+
+for t in range(T):
+    N=int(input())
+    ans = solv(N)
+    print(ans)


### PR DESCRIPTION
## [BOJ] 9461 파도반 수열
#### ⏰ 00:50  📌 DP 📈 O
### 문제
<https://www.acmicpc.net/problem/9461>

### 문제 해결

> 시간복잡도 O(T). T:문제에 주어진 테케 수
> 

1~8까지의 dp는 점화식으로 생각해내지 못 하여 그대로 정의
9 부터 `dp[i]=dp[i-1]+dp[i-5]`
101까지 존재하므로 101까지 진행한 후 dp[N] 리턴

### 피드백

내 풀이: dp[i]=dp[i-1]+dp[i-5]
다른 사람 풀이: dp[i]=dp[i-2]+dp[i-3]

DP는 풀이를 다양하게 아는게 중요한 것 같아서 해결 후에도 다른 풀이 방법 찾아보기
