### PR TITLE
seoyeon / 3월 2주차 화요일 / 1문제

### DIFF
--- a/seoyeon/백준/NAVER/1005.py
+++ b/seoyeon/백준/NAVER/1005.py
@@ -1,0 +1,43 @@
+#백준 #1005 ACM Craft
+#위상정렬
+#DP
+
+from collections import deque
+
+T = int(input())
+for t in range(T):
+    N,K = map(int,input().split()) #N:건물의 개수,K:건설규칙의 개수
+    times = list(map(int,input().split())) #times:해당 건물을 건설하는데 걸리는 시간
+    connections = [0 for _ in range(N+1)] #connections[i]는 i보다 먼저 건설되어야 하는 건물 수
+    connect_prev = [[] for _ in range(N+1)] #connect[i]는 i보다 먼저 건설되어야 하는 건물 리스트
+    connect_next = [[] for _ in range(N+1)]
+    dp = [0 for _ in range(N+1)] #dp: 해당 건물을 건설하는데 걸리는 총 시간
+
+    for k in range(K):
+        x,y = map(int,input().split()) #x->y
+        connections[y] += 1
+        
+        connect_prev[y].append(x)
+        connect_next[x].append(y)
+
+    Q = deque()
+    for i in range(1,N+1):
+        if connections[i]==0:
+            Q.append(i)
+
+    while Q:
+        current = Q.popleft()
+        
+        if len(connect_prev[current])==0:
+            dp[current] = times[current-1]
+        else:
+            for prev in connect_prev[current]:
+                dp[current] = max(dp[current],times[current-1],dp[prev]+times[current-1])
+            
+        for next in connect_next[current]:
+            connections[next] -= 1
+            if connections[next]==0:
+                Q.append(next)
+
+    W = int(input())
+    print(dp[W])


### PR DESCRIPTION
## [BOJ] 1005 ACM Craft
#### ⏰ 01:20  📌 DP, 위상정렬 📈 O
### 문제
<https://www.acmicpc.net/problem/1005>

### 문제 해결

> 시간복잡도 O(N+K). N:건물 수, K:건설 규칙 개수
> 

변수

- times[i]는 건물 i를 건설하는데 소요되는 시간
  - 0~N-1  
- connections[i]는 i보다 먼저 건설되어야 하는 건물 수
  - 1~N 
- connect_prev[i]는 i보다 먼저 건설되어야 하는 건물 리스트
  - 1~N 
- connect_next[i]는 i 이후에 건설되어야 하는 건물 리스트
  - 1~N
- dp[i]는 i까지 건설하는데 소요되는 총 시간
  - 1~N 

함수

- connections, connect_prev, connect_next 정의
- connections가 0인 건물 인덱스 Q에 삽입
- Q에서 인덱스를 하나씩 꺼내 dp 업데이트
  - connect_prev가 0인 경우 가장 처음 시작하는 건물이므로 `dp[current] = times[current-1]`
  - 그렇지 않은 경우 이전에 건설되어야 하는 건물 인덱스의 dp에 times[current-1]를 더한 값 중 가장 큰 값으로 업데이트
  - connect_next를 통해 이후 건설 인덱스의 connections 1 감소 후 0이 되면 Q에 삽입 

### 피드백

python3로 제출하니 시간초과 발생했는데 pypy3로 제출하니 정답